### PR TITLE
🧪 Add test for uncovered scanDir error path in trace command

### DIFF
--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -593,3 +593,33 @@ describe('CI detection expansion', () => {
     }
   });
 });
+
+describe('docguard trace error handling', () => {
+  it('gracefully handles missing project directory in scanDir', async () => {
+    // We mock runTrace from cli/commands/trace.mjs
+    const { runTrace } = await import('../cli/commands/trace.mjs');
+    const { mkdtempSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const assert = await import('node:assert');
+
+    const tmpDir = mkdtempSync(join(tmpdir(), 'docguard-trace-err-'));
+    const missingDir = join(tmpDir, 'does-not-exist');
+
+    try {
+      // Temporarily suppress console output to keep tests clean
+      const originalLog = console.log;
+      console.log = () => {};
+
+      // Should not throw an error, should just return gracefully
+      // due to the try/catch in scanDir
+      assert.doesNotThrow(() => {
+        runTrace(missingDir, { projectName: 'Test', requiredFiles: { canonical: [] } }, {});
+      });
+
+      console.log = originalLog;
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
🎯 **What:** An uncovered branch gap existed in `cli/commands/trace.mjs` line 294 within the `scanDir` helper function. `readdirSync` is called and wrapped in a try/catch, but this catch block was never covered in the test suite.
📊 **Coverage:** A test was added to explicitly pass a non-existent path to `runTrace` to ensure it falls through this try/catch block and executes the failure scenario without crashing the application.
✨ **Result:** Test coverage for `cli/commands/trace.mjs` has improved and the expected bug handling behavior is properly asserted to be resilient to missing directories.

---
*PR created automatically by Jules for task [9991815164320511039](https://jules.google.com/task/9991815164320511039) started by @raccioly*