### PR TITLE
🧪 [testing improvement] Add test for malformed package.json in docs-diff validator

### DIFF
--- a/cli/validators/docs-diff.mjs
+++ b/cli/validators/docs-diff.mjs
@@ -61,7 +61,7 @@ export function validateDocsDiff(projectDir, config) {
 
 // ── Diff Functions (lightweight versions for validator) ──────────────────
 
-function diffTechStack(dir) {
+export function diffTechStack(dir) {
   const archPath = resolve(dir, 'docs-canonical/ARCHITECTURE.md');
   const pkgPath = resolve(dir, 'package.json');
   if (!existsSync(archPath) || !existsSync(pkgPath)) return null;

--- a/tests/docs-diff.test.mjs
+++ b/tests/docs-diff.test.mjs
@@ -1,0 +1,31 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { diffTechStack } from '../cli/validators/docs-diff.mjs';
+
+describe('Docs-Diff Validator', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'docguard-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('handles malformed package.json gracefully', () => {
+    // Setup a malformed package.json and an ARCHITECTURE.md file
+    mkdirSync(join(tmpDir, 'docs-canonical'), { recursive: true });
+    writeFileSync(join(tmpDir, 'docs-canonical', 'ARCHITECTURE.md'), 'React, Node.js');
+    writeFileSync(join(tmpDir, 'package.json'), '{ "name": "test", "dependencies": { "react": "^18.0.0", } }'); // Invalid JSON (trailing comma)
+
+    const result = diffTechStack(tmpDir);
+
+    // Testing this requires creating a malformed package.json file and expecting a null return.
+    assert.strictEqual(result, null);
+  });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap in docs-diff.mjs where the JSON.parse error path for package.json was not covered has been addressed. The internal `diffTechStack` function was exported to test this scenario.
📊 **Coverage:** Covered the error path in `diffTechStack` by providing a malformed package.json file, asserting that the function catches the parsing error and safely returns `null` instead of throwing.
✨ **Result:** Test coverage for this previously missing edge case is complete.

---
*PR created automatically by Jules for task [9223058883345632969](https://jules.google.com/task/9223058883345632969) started by @raccioly*