### PR TITLE
🧹 [Code Health] Add error logging to empty catch block in drift validator

### DIFF
--- a/cli/validators/drift.mjs
+++ b/cli/validators/drift.mjs
@@ -4,6 +4,7 @@
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { resolve, join, extname } from 'node:path';
+import { c } from '../shared.mjs';
 
 const CODE_EXTENSIONS = new Set([
   '.js', '.mjs', '.cjs', '.ts', '.tsx', '.jsx',
@@ -94,8 +95,8 @@ function walkDir(dir, callback) {
       } else if (stat.isFile()) {
         callback(fullPath);
       }
-    } catch {
-      // Skip files we can't read
+    } catch (e) {
+      console.error(`${c.yellow}⚠ Warning: Could not read ${fullPath} during drift validation: ${e.message}${c.reset}`);
     }
   }
 }


### PR DESCRIPTION
### 🎯 **What**
Added an error log inside the empty catch block of the `walkDir` function in the drift validator (`cli/validators/drift.mjs`). The error log displays a warning with context about the unreadable file using `console.error` and styled with yellow coloring using `c.yellow`.

### 💡 **Why**
Swallowing errors silently when traversing directories can hide underlying issues such as lack of correct file permissions, or an unreadable file, which can disrupt drift validation process. Surfacing this via logging makes it explicit why a particular file couldn't be validated, increasing observability.

### ✅ **Verification**
1. Ran `npm test` successfully (all 46 tests passed).
2. Manually reviewed `cli/validators/drift.mjs` ensuring that `import { c } from '../shared.mjs'` and `console.error` logging are correct.

### ✨ **Result**
Better debuggability, error awareness, and overall observability when drift validation encounters unreadable files/directories. No behavior changes or crashes were introduced as the errors are still caught, just properly logged now.

---
*PR created automatically by Jules for task [15668144586107867445](https://jules.google.com/task/15668144586107867445) started by @raccioly*