### PR TITLE
🧪 Add tests for badge command

### DIFF
--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -71,6 +71,33 @@ describe('docguard audit', () => {
   });
 });
 
+
+describe('docguard badge', () => {
+  it('runs and shows badges', () => {
+    const output = run('badge');
+    assert.match(output, /DocGuard Badge/);
+    assert.match(output, /Score Badge:/);
+    assert.match(output, /Type Badge:/);
+    assert.match(output, /README snippet:/);
+    assert.match(output, /img\.shields\.io/);
+  });
+
+  it('outputs JSON with --format json', () => {
+    const output = run('badge --format json');
+    const jsonStart = output.indexOf('{');
+    const jsonStr = output.substring(jsonStart);
+    const parsed = JSON.parse(jsonStr);
+    assert.equal(typeof parsed.score, 'number');
+    assert.ok(parsed.grade);
+    assert.ok(parsed.color);
+    assert.ok(parsed.badges);
+    assert.ok(parsed.badges.score);
+    assert.ok(parsed.badges.type);
+    assert.ok(parsed.badges.docguard);
+    assert.ok(parsed.readmeSnippet);
+  });
+});
+
 describe('docguard score', () => {
   it('runs and shows a score', () => {
     const output = run('score');


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing tests for `runBadge` in `cli/commands/badge.mjs`.

📊 **Coverage:** What scenarios are now tested: The new tests cover the default output behavior as well as the JSON output structure when running the `badge` command.

✨ **Result:** The improvement in test coverage guarantees no regressions when modifying how badge output or its JSON equivalent gets generated.

---
*PR created automatically by Jules for task [11322711524067985020](https://jules.google.com/task/11322711524067985020) started by @raccioly*