### PR TITLE
🧪 Add tests for walkDir error handling in schemas scanner

### DIFF
--- a/docs-canonical/TEST-SPEC.md
+++ b/docs-canonical/TEST-SPEC.md
@@ -95,3 +95,4 @@ Test names follow the pattern: "verb + expected behavior" (e.g., "runs and shows
 | 0.5.0 | 2026-03-13 | @raccioly | Added diagnose, guard JSON, profile, tax tests (24→30) |
 | 0.3.0 | 2026-03-12 | @raccioly | Real tests, project-type-aware spec |
 | 0.1.0 | 2026-03-12 | DocGuard Generate | Auto-generated (corrected) |
+| `cli/scanners/schemas.mjs` | `tests/schemas.test.mjs` | ✅ |

--- a/tests/schemas.test.mjs
+++ b/tests/schemas.test.mjs
@@ -1,0 +1,42 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mock } from 'node:test';
+import fs from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { scanSchemasDeep } from '../cli/scanners/schemas.mjs';
+
+describe('schemas.mjs - walkDir error handling', () => {
+  it('should gracefully handle readdirSync errors during schema scan', () => {
+    // We create a temp dir structure that matches drizzle scanning (e.g. src/db)
+    const tempDir = fs.mkdtempSync(join(tmpdir(), 'docguard-test-schemas-'));
+    const drizzleDir = join(tempDir, 'src', 'db');
+    fs.mkdirSync(drizzleDir, { recursive: true });
+
+    // Write a dummy file so it's not totally empty if we wanted it to be found
+    fs.writeFileSync(join(drizzleDir, 'schema.ts'), 'export const users = pgTable("users", {});');
+
+    const originalReaddirSync = fs.readdirSync;
+
+    // Mock readdirSync to throw when reading the drizzle dir
+    mock.method(fs, 'readdirSync', (path, options) => {
+      if (typeof path === 'string' && path.includes(join('src', 'db'))) {
+        throw new Error('EACCES: permission denied');
+      }
+      return originalReaddirSync(path, options);
+    });
+
+    try {
+      // scanSchemasDeep will eventually call scanDrizzleSchemas, which calls walkDir
+      // If walkDir doesn't catch the error, this will throw and fail the test.
+      const result = scanSchemasDeep(tempDir, { orm: 'drizzle' }, {});
+
+      // We expect it to complete successfully, even though no entities might be found due to the error
+      assert.ok(result);
+      assert.ok(Array.isArray(result.entities));
+    } finally {
+      mock.restoreAll();
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
🎯 **What:** The try-catch block wrapping readdirSync in walkDir within `cli/scanners/schemas.mjs` lacked explicit test coverage, leaving a potential gap for unhandled EACCES/filesystem exceptions during directory traversal.

📊 **Coverage:** This is now tested via the `scanSchemasDeep` wrapper by simulating a permission error via node:test mock on `fs.readdirSync`. The test suite now validates whether `walkDir` correctly swallows the exception and allows execution to continue safely.

✨ **Result:** Ensure test framework confidence against regression in directory traversal error handling logic, improving overall test suite coverage.

---
*PR created automatically by Jules for task [14629114549164502174](https://jules.google.com/task/14629114549164502174) started by @raccioly*