### PR TITLE
⚡ Bolt: Fast early-returns for validators

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - [Optimizing Regex and split performance]
+**Learning:** Calling `content.split("\n")` on large files heavily allocates memory and triggers garbage collection overhead. Pre-screening the full content buffer using `.includes()` or `.test()` creates a massive speed boost by avoiding unnecessary string splitting and iteration.
+**Action:** Always prefer fast early returns in loops parsing files, deferring expensive operations until actual hits are found.

--- a/cli/validators/drift.mjs
+++ b/cli/validators/drift.mjs
@@ -27,6 +27,10 @@ export function validateDrift(projectDir, config) {
     if (!CODE_EXTENSIONS.has(ext)) return;
 
     const content = readFileSync(filePath, 'utf-8');
+
+    // Fast early return: if content doesn't contain DRIFT: comment keyword, don't split
+    if (!/DRIFT:/i.test(content)) return;
+
     const lines = content.split('\n');
 
     lines.forEach((line, i) => {

--- a/cli/validators/security.mjs
+++ b/cli/validators/security.mjs
@@ -74,12 +74,15 @@ export function validateSecurity(projectDir, config) {
     if (shouldIgnore(relPath, config, 'securityIgnore')) return;
 
     const content = readFileSync(filePath, 'utf-8');
-    const lines = content.split('\n');
+    let lines = null;
 
     for (const { pattern, label } of SECRET_PATTERNS) {
       pattern.lastIndex = 0;
       const match = pattern.exec(content);
       if (match) {
+        // Lazy initialize lines only if a match is found
+        if (!lines) lines = content.split('\n');
+
         // Find the line containing this match for context-aware filtering
         const matchPos = match.index;
         let charCount = 0;

--- a/cli/validators/todo-tracking.mjs
+++ b/cli/validators/todo-tracking.mjs
@@ -105,6 +105,11 @@ function checkSkippedTests(projectDir, config) {
     let content;
     try { content = readFileSync(fullPath, 'utf-8'); } catch { continue; }
 
+    // Fast early return: if content doesn't contain skip pattern keywords, don't split
+    if (!content.includes('skip') && !content.includes('todo') && !content.includes('xdescribe') && !content.includes('xit') && !content.includes('xtest')) {
+      continue;
+    }
+
     const lines = content.split('\n');
 
     for (let i = 0; i < lines.length; i++) {
@@ -305,6 +310,11 @@ function findTodos(rootDir, dir, todos, config) {
 
       let content;
       try { content = readFileSync(full, 'utf-8'); } catch { continue; }
+
+      // Fast early return: if content doesn't contain TODO_PATTERN keywords, don't split
+      if (!TODO_PATTERN.test(content)) {
+        continue;
+      }
 
       const lines = content.split('\n');
 

--- a/cli/validators/traceability.mjs
+++ b/cli/validators/traceability.mjs
@@ -193,6 +193,12 @@ function validateRequirementTraceability(projectDir, config, projectFiles) {
     if (!existsSync(docPath)) continue;
 
     const content = readFileSync(docPath, 'utf-8');
+
+    // Fast early return: if content doesn't match any of the patterns, don't split
+    if (!patterns.some(p => { p.lastIndex = 0; return p.test(content); })) {
+      continue;
+    }
+
     const lines = content.split('\n');
     const docName = relative(projectDir, docPath);
 
@@ -231,6 +237,12 @@ function validateRequirementTraceability(projectDir, config, projectFiles) {
 
     let content;
     try { content = readFileSync(fullPath, 'utf-8'); } catch { continue; }
+
+    // Fast early return: if content doesn't match any of the patterns, don't split
+    if (!patterns.some(p => { p.lastIndex = 0; return p.test(content); })) {
+      continue;
+    }
+
     const lines = content.split('\n');
 
     for (let i = 0; i < lines.length; i++) {


### PR DESCRIPTION
This PR optimizes memory usage and execution time for the `drift`, `security`, `todo-tracking`, and `traceability` validators by implementing fast early-returns. Instead of eagerly reading files and splitting them via `content.split('\n')`, we now use `String.prototype.includes` or `RegExp.prototype.test` directly on the content buffer to quickly filter out files lacking any matching keywords. 

For the security validator, where line context relies on multiple variables, it leverages lazy evaluation to only compute `content.split('\n')` when a string match is positively verified.

This leads to a noticeable boost in overall performance for large codebases.

---
*PR created automatically by Jules for task [7391540624069786846](https://jules.google.com/task/7391540624069786846) started by @raccioly*