### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in execSync

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-14 - [Prevent Command Injection in CLI commands]
+**Vulnerability:** Found multiple command injection vulnerabilities in `cli/commands/diagnose.mjs` and `cli/commands/fix.mjs` caused by executing Node.js sub-processes via `execSync` with strings concatenating the user-controlled `projectDir` variable. Since `execSync` spawns a shell under the hood to execute the string, an attacker could supply a `projectDir` value containing shell operators to execute arbitrary commands.
+**Learning:** `execSync` is inherently unsafe for running commands with dynamic, user-controlled data because it triggers shell interpretation.
+**Prevention:** Always use `execFileSync` from `node:child_process` when you need to execute a binary and pass dynamic inputs. Using an array of arguments for `execFileSync` securely passes the input without engaging a shell, entirely mitigating command injection vulnerabilities.

--- a/cli/commands/diagnose.mjs
+++ b/cli/commands/diagnose.mjs
@@ -20,7 +20,7 @@ import { detectAgentMode, isSpecKitInitialized } from '../ensure-skills.mjs';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 // Map validator failures to the right fix --doc target
 const VALIDATOR_TO_DOC = {
@@ -127,7 +127,7 @@ export function runDiagnose(projectDir, config, flags) {
       // Run init to create missing files
       try {
         const cliPath = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'docguard.mjs');
-        execSync(`node "${cliPath}" init --dir "${projectDir}"`, {
+        execFileSync(process.execPath, [cliPath, 'init', '--dir', projectDir], {
           encoding: 'utf-8',
           stdio: 'pipe',
         });
@@ -136,7 +136,7 @@ export function runDiagnose(projectDir, config, flags) {
       // Run generate to fill in MISSING content only (never --force, which would overwrite existing docs)
       try {
         const cliPath = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'docguard.mjs');
-        execSync(`node "${cliPath}" generate --dir "${projectDir}"`, {
+        execFileSync(process.execPath, [cliPath, 'generate', '--dir', projectDir], {
           encoding: 'utf-8',
           stdio: 'pipe',
         });

--- a/cli/commands/fix.mjs
+++ b/cli/commands/fix.mjs
@@ -15,7 +15,7 @@
 
 import { existsSync, readFileSync, mkdirSync } from 'node:fs';
 import { resolve, basename, dirname } from 'node:path';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { c } from '../shared.mjs';
 
@@ -473,7 +473,7 @@ function autoFixIssues(projectDir, config, issues) {
 
   try {
     const cliPath = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'docguard.mjs');
-    execSync(`node ${cliPath} init --dir "${projectDir}"`, {
+    execFileSync(process.execPath, [cliPath, 'init', '--dir', projectDir], {
       encoding: 'utf-8',
       stdio: 'pipe',
     });


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unsafe usage of `execSync` in `cli/commands/diagnose.mjs` and `cli/commands/fix.mjs` directly interpolated the user-controlled `projectDir` parameter into command strings. Since `execSync` leverages a shell for execution, an attacker could supply inputs containing shell operators (e.g. `; rm -rf /`) to execute arbitrary commands.
🎯 **Impact:** Arbitrary Command Injection/Execution allowing an attacker to execute unintended commands under the host system.
🔧 **Fix:** Refactored the unsafe `execSync` invocations to `execFileSync`. By passing `process.execPath` along with an explicit argument list, shell evaluation is completely bypassed, securing the inputs without any structural changes.
✅ **Verification:** Verified that tests pass via `npm test` and ensuring `.jules/sentinel.md` journal has logged this specific learning.

---
*PR created automatically by Jules for task [6752136646732530680](https://jules.google.com/task/6752136646732530680) started by @raccioly*