### PR TITLE
⚡ Bolt: optimize TODO/FIXME scanning with early returns

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [Avoid `String.prototype.split` when not needed for boolean checks]
+**Learning:** `String.prototype.split` creates arrays and strings which allocate memory and garbage collect. This can be super costly when scanning through thousands of files or very large files. If you only need to check if a pattern matches, then `String.prototype.includes` or `RegExp.prototype.test` is magnitudes faster.
+**Action:** When searching for patterns or strings over large files in validators/scanners, defer calling `.split("\n")` until we have proven that the pattern matches via `RegExp.test(content)` or `String.includes()`. This acts as an early-return optimization.

--- a/cli/validators/todo-tracking.mjs
+++ b/cli/validators/todo-tracking.mjs
@@ -105,6 +105,9 @@ function checkSkippedTests(projectDir, config) {
     let content;
     try { content = readFileSync(fullPath, 'utf-8'); } catch { continue; }
 
+    // Fast early-return to avoid expensive split if no skips exist
+    if (!SKIP_PATTERNS.some(p => p.test(content))) continue;
+
     const lines = content.split('\n');
 
     for (let i = 0; i < lines.length; i++) {
@@ -305,6 +308,9 @@ function findTodos(rootDir, dir, todos, config) {
 
       let content;
       try { content = readFileSync(full, 'utf-8'); } catch { continue; }
+
+      // Fast early-return if no TODO exists
+      if (!TODO_PATTERN.test(content)) continue;
 
       const lines = content.split('\n');
 


### PR DESCRIPTION
💡 **What**: Added early return checks using `RegExp.test` on the entire file contents before performing an expensive `.split('\n')` in `cli/validators/todo-tracking.mjs` for scanning tests skips and TODO comments. 

🎯 **Why**: When scanning large files during validation, allocating string chunks in memory due to `split('\n')` becomes incredibly taxing. Only a small fraction of files normally contain test skips or TODO/FIXME annotations. We can immediately prune these out using `.test(content)` to detect skips or TODOs without needing the line-by-line array layout.

📊 **Impact**: Massive performance enhancement reducing latency and memory usage scaling relative to the target project size. Skips large file allocations and Garbage Collection churn.

🔬 **Measurement**: Run the command `node --test tests/*.test.mjs` to ensure validations correctly output results for test specs and TODOs still function equivalently.

---
*PR created automatically by Jules for task [18340490612319394510](https://jules.google.com/task/18340490612319394510) started by @raccioly*