### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Command Injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-18 - [Command Injection via execSync]
+**Vulnerability:** Found multiple instances where user-controlled inputs (`projectDir`, `filePath`) were interpolated directly into shell commands via `execSync` (e.g., `execSync(\`node "\${cliPath}" init --dir "\${projectDir}"\`)`).
+**Learning:** This is a classic command injection vulnerability. If `projectDir` contains shell metacharacters like `;`, `&&`, or `||`, it allows arbitrary command execution.
+**Prevention:** Always use `execFileSync` (or `execFile` for async) instead of `execSync` when executing commands with dynamic inputs. Pass arguments as an array to ensure they are passed directly to the executable without shell interpolation.

--- a/cli/commands/diagnose.mjs
+++ b/cli/commands/diagnose.mjs
@@ -20,7 +20,7 @@ import { detectAgentMode, isSpecKitInitialized } from '../ensure-skills.mjs';
 import { existsSync, readFileSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 
 // Map validator failures to the right fix --doc target
 const VALIDATOR_TO_DOC = {
@@ -127,7 +127,7 @@ export function runDiagnose(projectDir, config, flags) {
       // Run init to create missing files
       try {
         const cliPath = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'docguard.mjs');
-        execSync(`node "${cliPath}" init --dir "${projectDir}"`, {
+        execFileSync(process.execPath, [cliPath, 'init', '--dir', projectDir], {
           encoding: 'utf-8',
           stdio: 'pipe',
         });
@@ -136,7 +136,7 @@ export function runDiagnose(projectDir, config, flags) {
       // Run generate to fill in MISSING content only (never --force, which would overwrite existing docs)
       try {
         const cliPath = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'docguard.mjs');
-        execSync(`node "${cliPath}" generate --dir "${projectDir}"`, {
+        execFileSync(process.execPath, [cliPath, 'generate', '--dir', projectDir], {
           encoding: 'utf-8',
           stdio: 'pipe',
         });

--- a/cli/commands/fix.mjs
+++ b/cli/commands/fix.mjs
@@ -15,7 +15,7 @@
 
 import { existsSync, readFileSync, mkdirSync } from 'node:fs';
 import { resolve, basename, dirname } from 'node:path';
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { c } from '../shared.mjs';
 
@@ -473,7 +473,7 @@ function autoFixIssues(projectDir, config, issues) {
 
   try {
     const cliPath = resolve(dirname(fileURLToPath(import.meta.url)), '..', 'docguard.mjs');
-    execSync(`node ${cliPath} init --dir "${projectDir}"`, {
+    execFileSync(process.execPath, [cliPath, 'init', '--dir', projectDir], {
       encoding: 'utf-8',
       stdio: 'pipe',
     });

--- a/cli/validators/doc-quality.mjs
+++ b/cli/validators/doc-quality.mjs
@@ -23,7 +23,7 @@
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { resolve, join, extname } from 'node:path';
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 
 // ──── Metric Thresholds ────
 // These define "good" vs "warning" boundaries for each metric.
@@ -464,9 +464,10 @@ function findUnderstandingCli() {
  */
 function runUnderstandingDeepScan(filePath) {
   try {
-    const result = execSync(`understanding analyze "${filePath}" --enhanced --json 2>/dev/null`, {
+    const result = execFileSync('understanding', ['analyze', filePath, '--enhanced', '--json'], {
       encoding: 'utf-8',
       timeout: 10000,
+      stdio: ['pipe', 'pipe', 'ignore'],
     });
     return JSON.parse(result);
   } catch {


### PR DESCRIPTION
🚨 Severity: CRITICAL

💡 Vulnerability: Command injection vulnerability was present due to the direct interpolation of user-controlled variables (`projectDir`, `filePath`) into string commands executed via `execSync`. If these variables contain shell metacharacters, an attacker could execute arbitrary commands.

🎯 Impact: An attacker could achieve arbitrary code execution on the host machine running the CLI if they can control the directory name or file path processed by the tool.

🔧 Fix: Replaced `execSync` with `execFileSync` in `cli/commands/diagnose.mjs`, `cli/commands/fix.mjs`, and `cli/validators/doc-quality.mjs`. Arguments are now explicitly passed as arrays, which prevents the shell from interpreting any metacharacters. In `cli/validators/doc-quality.mjs`, standard error redirection (`2>/dev/null`) was replaced with the `stdio: ['pipe', 'pipe', 'ignore']` option for secure output handling.

✅ Verification: The test suite was run (`npm test`) and all 61 tests passed without any regressions. The codebase no longer contains vulnerable `execSync` usages with dynamically interpolated paths.

---
*PR created automatically by Jules for task [5019574399015031273](https://jules.google.com/task/5019574399015031273) started by @raccioly*