### PR TITLE
⚡ Bolt: [performance improvement] Add early returns to bypass expensive split('\\n')

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - [Optimization]
+**Learning:** Found string.includes early return could speed up checkUntrackedTodos in cli/validators/todo-tracking.mjs.
+**Action:** Implement fast early return with includes check before doing expensive splitting or matching.

--- a/cli/validators/drift.mjs
+++ b/cli/validators/drift.mjs
@@ -27,6 +27,10 @@ export function validateDrift(projectDir, config) {
     if (!CODE_EXTENSIONS.has(ext)) return;
 
     const content = readFileSync(filePath, 'utf-8');
+
+    // Fast early-return: skip expensive string split if no comment exists
+    if (!content.includes('DRIFT:')) return;
+
     const lines = content.split('\n');
 
     lines.forEach((line, i) => {

--- a/cli/validators/security.mjs
+++ b/cli/validators/security.mjs
@@ -74,12 +74,15 @@ export function validateSecurity(projectDir, config) {
     if (shouldIgnore(relPath, config, 'securityIgnore')) return;
 
     const content = readFileSync(filePath, 'utf-8');
-    const lines = content.split('\n');
+    let lines = null;
 
     for (const { pattern, label } of SECRET_PATTERNS) {
       pattern.lastIndex = 0;
       const match = pattern.exec(content);
       if (match) {
+        // Lazily initialize lines only when a match is found
+        if (!lines) lines = content.split('\n');
+
         // Find the line containing this match for context-aware filtering
         const matchPos = match.index;
         let charCount = 0;

--- a/cli/validators/todo-tracking.mjs
+++ b/cli/validators/todo-tracking.mjs
@@ -105,6 +105,10 @@ function checkSkippedTests(projectDir, config) {
     let content;
     try { content = readFileSync(fullPath, 'utf-8'); } catch { continue; }
 
+    // Fast early-return: skip expensive string split if no skip patterns exist
+    const hasSkip = SKIP_PATTERNS.some(p => p.test(content));
+    if (!hasSkip) continue;
+
     const lines = content.split('\n');
 
     for (let i = 0; i < lines.length; i++) {
@@ -305,6 +309,9 @@ function findTodos(rootDir, dir, todos, config) {
 
       let content;
       try { content = readFileSync(full, 'utf-8'); } catch { continue; }
+
+      // Fast early-return: skip expensive string split if no TODO patterns exist
+      if (!TODO_PATTERN.test(content)) continue;
 
       const lines = content.split('\n');
 

--- a/cli/validators/traceability.mjs
+++ b/cli/validators/traceability.mjs
@@ -193,6 +193,11 @@ function validateRequirementTraceability(projectDir, config, projectFiles) {
     if (!existsSync(docPath)) continue;
 
     const content = readFileSync(docPath, 'utf-8');
+
+    // Fast early-return: skip expensive string split if no requirement patterns exist
+    const hasMatch = patterns.some(p => { p.lastIndex = 0; return p.test(content); });
+    if (!hasMatch) continue;
+
     const lines = content.split('\n');
     const docName = relative(projectDir, docPath);
 
@@ -231,6 +236,11 @@ function validateRequirementTraceability(projectDir, config, projectFiles) {
 
     let content;
     try { content = readFileSync(fullPath, 'utf-8'); } catch { continue; }
+
+    // Fast early-return: skip expensive string split if no requirement patterns exist
+    const hasMatch = patterns.some(p => { p.lastIndex = 0; return p.test(content); });
+    if (!hasMatch) continue;
+
     const lines = content.split('\n');
 
     for (let i = 0; i < lines.length; i++) {


### PR DESCRIPTION
💡 **What:** Added fast early-returns using `String.prototype.includes()` and `RegExp.prototype.test()` before executing expensive `.split('\n')` calls in `cli/validators/drift.mjs`, `cli/validators/todo-tracking.mjs`, and `cli/validators/traceability.mjs`. In `cli/validators/security.mjs`, implemented lazy initialization of the `.split('\n')` array only when a match occurs.
🎯 **Why:** To optimize memory allocations and speed up the CLI. Searching the entire raw file content string first is significantly faster and allocates less memory than splitting large files into arrays of lines. This will speed up execution on large codebases.
📊 **Impact:** Reduces memory allocations and significantly cuts down time processing non-matching large files.
🔬 **Measurement:** Verify by running the CLI `guard` command on a large codebase before and after this change, measuring both execution time and peak memory usage. Also validated via `npm test` to ensure logic correctness.

---
*PR created automatically by Jules for task [5607880322268012011](https://jules.google.com/task/5607880322268012011) started by @raccioly*