### PR TITLE
🎨 Palette: Make status bar tooltip context-aware

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,7 @@
+## 2024-04-16 - Web UI Components Constraint
+**Learning:** The docguard repository consists entirely of a Node.js CLI tool and a VS Code extension; it lacks web UI components (e.g., HTML, CSS, React, Vue), meaning traditional web-focused micro-UX enhancements do not apply.
+**Action:** Do not attempt traditional web-based UX enhancements here. Focus on CLI paradigms or skip UX enhancement requests if web-centric.
+
+## 2024-04-16 - Context-Aware Status Bar Tooltips
+**Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
+**Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -224,12 +224,14 @@ async function refreshScore() {
 
     // Update status bar
     let icon;
-    if (score >= 90) icon = '$(verified)';
-    else if (score >= 80) icon = '$(pass)';
-    else if (score >= threshold) icon = '$(info)';
-    else icon = '$(warning)';
+    let tooltipStatus;
+    if (score >= 90) { icon = '$(verified)'; tooltipStatus = 'Excellent'; }
+    else if (score >= 80) { icon = '$(pass)'; tooltipStatus = 'Good'; }
+    else if (score >= threshold) { icon = '$(info)'; tooltipStatus = 'Passing'; }
+    else { icon = '$(warning)'; tooltipStatus = `Below minimum threshold (${threshold})`; }
 
     statusBarItem.text = `${icon} CDD: ${score}/100 (${grade})`;
+    statusBarItem.tooltip = `CDD Score: ${score}/100 - ${tooltipStatus}\nClick to see details`;
     statusBarItem.backgroundColor = score < threshold
       ? new vscode.ThemeColor('statusBarItem.warningBackground')
       : undefined;


### PR DESCRIPTION
💡 What: Added dynamic, context-aware tooltip text to the VS Code extension status bar item.
🎯 Why: Previously, the status bar showed a generic "Click to see CDD score details" tooltip. When the score dipped below the required threshold, a warning icon appeared, but the reason wasn't explicitly clear on hover. By adding a context-aware tooltip (e.g., "Below minimum threshold (60)"), users get immediate, clear feedback on *why* the visual state changed without needing to click into the logs.
📸 Before/After: 
  * Before: Tooltip always read "Click to see CDD score details".
  * After: Tooltip reads "CDD Score: [score]/100 - [Excellent|Good|Passing|Below minimum threshold (XX)]\nClick to see details".
♿ Accessibility: Improves cognitive accessibility by explicitly textually describing what the color and icon changes mean, rather than relying solely on visual cues (warning icon and background color) to convey the threshold failure state.

---
*PR created automatically by Jules for task [12485343234348179062](https://jules.google.com/task/12485343234348179062) started by @raccioly*