### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Command Injection via File Path

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Command Injection via File Path in execSync
+**Vulnerability:** Command injection was possible in `cli/validators/freshness.mjs` and `cli/validators/doc-quality.mjs` because user-controlled file paths were passed unescaped directly into a string concatenated for `execSync`.
+**Learning:** Even internal CLI tools processing local repository files can be vulnerable to command injection if filenames or directory structures contain shell characters or are crafted maliciously.
+**Prevention:** Always use `execFileSync` instead of `execSync` when dealing with external inputs, file paths, or complex parameters. Pass the command arguments as a distinct array and emulate shell behaviors (like `2>/dev/null`) natively using `stdio: ['pipe', 'pipe', 'ignore']`.

--- a/cli/validators/doc-quality.mjs
+++ b/cli/validators/doc-quality.mjs
@@ -23,7 +23,7 @@
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { resolve, join, extname } from 'node:path';
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 
 // ──── Metric Thresholds ────
 // These define "good" vs "warning" boundaries for each metric.
@@ -464,9 +464,10 @@ function findUnderstandingCli() {
  */
 function runUnderstandingDeepScan(filePath) {
   try {
-    const result = execSync(`understanding analyze "${filePath}" --enhanced --json 2>/dev/null`, {
+    const result = execFileSync('understanding', ['analyze', filePath, '--enhanced', '--json'], {
       encoding: 'utf-8',
       timeout: 10000,
+      stdio: ['pipe', 'pipe', 'ignore']
     });
     return JSON.parse(result);
   } catch {

--- a/cli/validators/freshness.mjs
+++ b/cli/validators/freshness.mjs
@@ -8,7 +8,7 @@
 
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import { resolve, join, extname } from 'node:path';
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 
 const IGNORE_DIRS = new Set([
   'node_modules', '.git', '.next', 'dist', 'build',
@@ -22,8 +22,9 @@ const IGNORE_DIRS = new Set([
  */
 function getLastGitDate(filePath, dir) {
   try {
-    const result = execSync(
-      `git log -1 --format="%aI" -- "${filePath}"`,
+    const result = execFileSync(
+      'git',
+      ['log', '-1', '--format=%aI', '--', filePath],
       { cwd: dir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }
     ).trim();
     return result ? new Date(result) : null;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command injection via `execSync` where file paths were concatenated directly into shell commands in `cli/validators/freshness.mjs` and `cli/validators/doc-quality.mjs`.
🎯 Impact: A malicious actor could execute arbitrary code by supplying specifically crafted file paths containing shell meta-characters (like `"; rm -rf /; "`).
🔧 Fix: Replaced `execSync` with `execFileSync`, passing user-controlled parameters safely as an array of arguments, bypassing shell interpolation. Used `stdio` configuration to replicate output suppression.
✅ Verification: Ran `npm test` successfully to ensure no regressions were introduced. Added learnings to Sentinel journal.

---
*PR created automatically by Jules for task [16810225177531653829](https://jules.google.com/task/16810225177531653829) started by @raccioly*