### PR TITLE
⚡ Bolt: [performance improvement] Defer `.split('\n')` to avoid unnecessary array allocations in validators

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2026-04-16 - Defer String Splitting
+
+**Learning:** When scanning large files in pure Node.js without streams, unconditionally splitting file contents via `content.split('\n')` introduces significant memory allocation and garbage collection overhead, especially when the target strings or regex patterns (e.g., secrets, TODOs) are rarely found.
+**Action:** Use `String.prototype.includes()` or `RegExp.prototype.test()` as a fast, low-memory pre-flight check on the full file string. Only execute `content.split('\n')` if a match is found, thereby avoiding unnecessary array allocations on the happy path.

--- a/cli/validators/drift.mjs
+++ b/cli/validators/drift.mjs
@@ -27,6 +27,7 @@ export function validateDrift(projectDir, config) {
     if (!CODE_EXTENSIONS.has(ext)) return;
 
     const content = readFileSync(filePath, 'utf-8');
+    if (!content.includes('DRIFT:')) return;
     const lines = content.split('\n');
 
     lines.forEach((line, i) => {

--- a/cli/validators/security.mjs
+++ b/cli/validators/security.mjs
@@ -74,7 +74,7 @@ export function validateSecurity(projectDir, config) {
     if (shouldIgnore(relPath, config, 'securityIgnore')) return;
 
     const content = readFileSync(filePath, 'utf-8');
-    const lines = content.split('\n');
+    let lines = null;
 
     for (const { pattern, label } of SECRET_PATTERNS) {
       pattern.lastIndex = 0;
@@ -84,6 +84,7 @@ export function validateSecurity(projectDir, config) {
         const matchPos = match.index;
         let charCount = 0;
         let matchLine = '';
+        if (!lines) lines = content.split('\n');
         for (const line of lines) {
           charCount += line.length + 1; // +1 for newline
           if (charCount > matchPos) {

--- a/cli/validators/todo-tracking.mjs
+++ b/cli/validators/todo-tracking.mjs
@@ -105,6 +105,8 @@ function checkSkippedTests(projectDir, config) {
     let content;
     try { content = readFileSync(fullPath, 'utf-8'); } catch { continue; }
 
+    if (!SKIP_PATTERNS.some(p => p.test(content))) continue;
+
     const lines = content.split('\n');
 
     for (let i = 0; i < lines.length; i++) {
@@ -305,6 +307,8 @@ function findTodos(rootDir, dir, todos, config) {
 
       let content;
       try { content = readFileSync(full, 'utf-8'); } catch { continue; }
+
+      if (!TODO_PATTERN.test(content)) continue;
 
       const lines = content.split('\n');
 

--- a/cli/validators/traceability.mjs
+++ b/cli/validators/traceability.mjs
@@ -193,6 +193,9 @@ function validateRequirementTraceability(projectDir, config, projectFiles) {
     if (!existsSync(docPath)) continue;
 
     const content = readFileSync(docPath, 'utf-8');
+
+    if (!patterns.some(p => p.test(content))) continue;
+
     const lines = content.split('\n');
     const docName = relative(projectDir, docPath);
 
@@ -231,6 +234,9 @@ function validateRequirementTraceability(projectDir, config, projectFiles) {
 
     let content;
     try { content = readFileSync(fullPath, 'utf-8'); } catch { continue; }
+
+    if (!patterns.some(p => p.test(content))) continue;
+
     const lines = content.split('\n');
 
     for (let i = 0; i < lines.length; i++) {


### PR DESCRIPTION
💡 **What**: Added `String.prototype.includes()` and `RegExp.prototype.test()` conditions before using `.split('\n')` across several document validators (`drift.mjs`, `security.mjs`, `todo-tracking.mjs`, `traceability.mjs`).

🎯 **Why**: When scanning extensive repositories, unconditionally splitting entire file contents into line arrays generates considerable memory overhead and slows execution, especially since target phrases (like `// DRIFT:`, `TODO:`, or API secrets) are exceedingly rare in the full scan.

📊 **Impact**: Minimizes unnecessary memory allocation for array structures in large files. Should noticeably speed up `pnpm test` and `docguard guard` executions on massive codebases since the happy path for validators now runs a fast `.test()` pattern on native C++ backed string types.

🔬 **Measurement**: Verified the overall system operates consistently with these string optimizations via integration tests. The changes are expected to drop peak memory significantly during long-running tasks.

---
*PR created automatically by Jules for task [16782160728279893285](https://jules.google.com/task/16782160728279893285) started by @raccioly*