### PR TITLE
🎨 Palette: [UX improvement] Add accessibility info to status bar

### DIFF
--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -29,6 +29,7 @@ function activate(context) {
   );
   statusBarItem.command = 'specguard.score';
   statusBarItem.tooltip = 'Click to see CDD score details';
+  statusBarItem.accessibilityInformation = { label: 'CDD Score: Unknown', role: 'button' };
   context.subscriptions.push(statusBarItem);
 
   // Diagnostics
@@ -213,6 +214,7 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.accessibilityInformation = { label: 'CDD Score: Unknown', role: 'button' };
       statusBarItem.show();
       return;
     }
@@ -232,6 +234,7 @@ async function refreshScore() {
 
     statusBarItem.text = `${icon} CDD: ${score}/100 (${grade})`;
     statusBarItem.tooltip = `CDD Score: ${score}/100 - ${tooltipStatus}\nClick to see details`;
+    statusBarItem.accessibilityInformation = { label: `CDD Score: ${score} out of 100, ${tooltipStatus}`, role: 'button' };
     statusBarItem.backgroundColor = score < threshold
       ? new vscode.ThemeColor('statusBarItem.warningBackground')
       : undefined;
@@ -243,6 +246,7 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.accessibilityInformation = { label: 'CDD Score: Error', role: 'button' };
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 What: Added `accessibilityInformation` property to the DocGuard CDD Score status bar item in the VS Code extension.
🎯 Why: Status bar items often rely on icons (like `$(shield)`) or shorthand text (`CDD: ?`). This makes it difficult for screen reader users to understand the current CDD score or its threshold status. Setting explicit `accessibilityInformation` provides clear, spoken context.
📸 Before/After: N/A (Visuals remain the same, but screen readers will now announce "CDD Score: [value] out of 100, [status]" instead of "shield CDD question mark").
♿ Accessibility: Improves accessibility for visually impaired users by adding explicit ARIA-like labels (`label` and `role: 'button'`) to dynamic VS Code status bar elements, adapting to all UI states (initialization, success, and error).

---
*PR created automatically by Jules for task [5147361732112302678](https://jules.google.com/task/5147361732112302678) started by @raccioly*