### PR TITLE
🎨 Palette: Add accessibilityInformation to StatusBarItem

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2026-04-19 - Add accessibilityInformation to VS Code StatusBarItem
+**Learning:** VS Code StatusBarItems using shorthand text or icons need explicit `accessibilityInformation` to provide clear spoken context for screen readers.
+**Action:** Always set `accessibilityInformation` with a descriptive `label` and `role` when creating UI elements in VS Code extensions, and update it dynamically if the content changes.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -29,6 +29,7 @@ function activate(context) {
   );
   statusBarItem.command = 'specguard.score';
   statusBarItem.tooltip = 'Click to see CDD score details';
+  statusBarItem.accessibilityInformation = { label: 'SpecGuard CDD Score', role: 'button' };
   context.subscriptions.push(statusBarItem);
 
   // Diagnostics
@@ -213,6 +214,7 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.accessibilityInformation = { label: 'SpecGuard CDD Score Unknown', role: 'button' };
       statusBarItem.show();
       return;
     }
@@ -232,6 +234,7 @@ async function refreshScore() {
 
     statusBarItem.text = `${icon} CDD: ${score}/100 (${grade})`;
     statusBarItem.tooltip = `CDD Score: ${score}/100 - ${tooltipStatus}\nClick to see details`;
+    statusBarItem.accessibilityInformation = { label: `SpecGuard CDD Score: ${score} out of 100, ${tooltipStatus}`, role: 'button' };
     statusBarItem.backgroundColor = score < threshold
       ? new vscode.ThemeColor('statusBarItem.warningBackground')
       : undefined;
@@ -243,6 +246,7 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.accessibilityInformation = { label: 'SpecGuard CDD Score Unknown', role: 'button' };
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 What
Added `accessibilityInformation` to the VS Code extension's `StatusBarItem`.

🎯 Why
The SpecGuard CDD score StatusBarItem relies on shorthand text and icons (e.g., `$(shield) CDD: 85/100`), which does not provide enough context for screen reader users. Adding explicit labels ensures the state and score are correctly vocalized.

📸 Before/After
N/A - This is an accessibility enhancement with no visual changes.

♿ Accessibility
Provides clear spoken context for screen readers when they focus on the SpecGuard CDD score status bar item, dynamically updating the label when the score refreshes or errors.

---
*PR created automatically by Jules for task [6210954644681198215](https://jules.google.com/task/6210954644681198215) started by @raccioly*