### PR TITLE
⚡ Bolt: Optimize line counting in generate command

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - [Optimization]
 **Learning:** Found string.includes early return could speed up checkUntrackedTodos in cli/validators/todo-tracking.mjs.
 **Action:** Implement fast early return with includes check before doing expensive splitting or matching.
+
+## 2024-05-18 - [Optimization] Counting Lines Efficiently
+**Learning:** Using `String.prototype.split('\n').length` to count lines forces unnecessary array allocation, creating garbage collection overhead for large files.
+**Action:** Use a `while` loop with `String.prototype.indexOf('\n')` to iterate through strings and count lines without allocating memory for an array.

--- a/cli/commands/generate.mjs
+++ b/cli/commands/generate.mjs
@@ -472,7 +472,15 @@ function countFilesAndLines(dir, scan) {
     scan.totalFiles++;
     try {
       const content = readFileSync(filePath, 'utf-8');
-      scan.totalLines += content.split('\n').length;
+
+      // Optimize line counting by avoiding array allocation
+      let lineCount = 1;
+      let pos = content.indexOf('\n');
+      while (pos !== -1) {
+        lineCount++;
+        pos = content.indexOf('\n', pos + 1);
+      }
+      scan.totalLines += lineCount;
     } catch { /* skip binary files */ }
   });
 }


### PR DESCRIPTION
💡 **What:** Replaced `content.split('\n').length` with a `while` loop using `String.prototype.indexOf('\n')` inside the `countFilesAndLines` function in `cli/commands/generate.mjs`.
🎯 **Why:** The previous approach allocated a new array containing every line of the file just to count its length. On large codebases or large files, this creates significant, unnecessary memory allocation and triggers frequent garbage collection pauses, slowing down the CLI execution.
📊 **Impact:** Reduces memory overhead and avoids unnecessary array creation during file scanning when executing the `generate` command. Time spent in GC should drop noticeably during large scans.
🔬 **Measurement:** You can verify this by running `docguard generate` on a massive directory. The time to scan and the peak memory usage (measureable via `--inspect`) will be improved since array allocation has been entirely removed from the hot path.

---
*PR created automatically by Jules for task [4049517530796705445](https://jules.google.com/task/4049517530796705445) started by @raccioly*