### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - [Optimization]
 **Learning:** Found string.includes early return could speed up checkUntrackedTodos in cli/validators/todo-tracking.mjs.
 **Action:** Implement fast early return with includes check before doing expensive splitting or matching.
+
+## 2025-05-20 - [Optimization]
+**Learning:** Avoid redundant `statSync` calls during directory traversal. Using `readdirSync(dir, { withFileTypes: true })` provides directory entry objects that have `.isDirectory()` and `.isFile()` methods directly, avoiding the need for an expensive filesystem call for every entry.
+**Action:** Always use `withFileTypes: true` when reading directories if we need to know the entry type, rather than calling `statSync` separately.

--- a/cli/validators/docs-diff.mjs
+++ b/cli/validators/docs-diff.mjs
@@ -195,17 +195,16 @@ export function getTestFilesFromPatterns(dir, patterns, config) {
 
   function walk(currentDir) {
     let entries;
-    try { entries = readdirSync(currentDir); } catch { return; }
+    try { entries = readdirSync(currentDir, { withFileTypes: true }); } catch { return; }
 
     for (const entry of entries) {
       // Skip node_modules and other ignored dirs at directory level (fast path)
-      if (IGNORE_DIRS.has(entry) || entry.startsWith('.')) continue;
-      const fullPath = join(currentDir, entry);
+      if (IGNORE_DIRS.has(entry.name) || entry.name.startsWith('.')) continue;
+      const fullPath = join(currentDir, entry.name);
       try {
-        const stat = statSync(fullPath);
-        if (stat.isDirectory()) {
+        if (entry.isDirectory()) {
           walk(fullPath);
-        } else if (stat.isFile()) {
+        } else if (entry.isFile()) {
           const relPath = relative(dir, fullPath);
           // Skip files in globally ignored paths
           if (config && shouldIgnore(relPath, config)) continue;
@@ -226,16 +225,15 @@ function getFilesRecursive(dir, config) {
   const results = [];
   if (!existsSync(dir)) return results;
   let entries;
-  try { entries = readdirSync(dir); } catch { return results; }
+  try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return results; }
 
   for (const entry of entries) {
-    if (IGNORE_DIRS.has(entry) || entry.startsWith('.')) continue;
-    const fullPath = join(dir, entry);
+    if (IGNORE_DIRS.has(entry.name) || entry.name.startsWith('.')) continue;
+    const fullPath = join(dir, entry.name);
     try {
-      const stat = statSync(fullPath);
-      if (stat.isDirectory()) {
+      if (entry.isDirectory()) {
         results.push(...getFilesRecursive(fullPath, config));
-      } else if (stat.isFile() && CODE_EXTENSIONS.has(extname(fullPath))) {
+      } else if (entry.isFile() && CODE_EXTENSIONS.has(extname(fullPath))) {
         results.push(fullPath);
       }
     } catch { /* skip */ }


### PR DESCRIPTION
⚡ Bolt: [performance improvement]

💡 What: Updated `getTestFilesFromPatterns` and `getFilesRecursive` in `cli/validators/docs-diff.mjs` to use `readdirSync(dir, { withFileTypes: true })`.
🎯 Why: Using `withFileTypes: true` returns `fs.Dirent` objects which provide `.isDirectory()` and `.isFile()` methods directly, completely eliminating the need to execute redundant `statSync` calls for every file and directory encountered during traversal. This reduces I/O operations significantly on larger codebases.
📊 Impact: Halves the number of filesystem read operations (I/O) during directory walking within the docs-diff validator, speeding up execution significantly on large codebases.
🔬 Measurement: Run `pnpm test` (which includes tests that exercise this file traversal logic) and observe it completes correctly without errors. The theoretical savings are O(N) `stat` operations where N is the total number of files and directories scanned.

---
*PR created automatically by Jules for task [5859546069590656426](https://jules.google.com/task/5859546069590656426) started by @raccioly*