### PR TITLE
🎨 Palette: [UX improvement] Add screen reader accessibility to status bar item

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,7 +1,3 @@
-## 2024-04-16 - Web UI Components Constraint
-**Learning:** The docguard repository consists entirely of a Node.js CLI tool and a VS Code extension; it lacks web UI components (e.g., HTML, CSS, React, Vue), meaning traditional web-focused micro-UX enhancements do not apply.
-**Action:** Do not attempt traditional web-based UX enhancements here. Focus on CLI paradigms or skip UX enhancement requests if web-centric.
-
-## 2024-04-16 - Context-Aware Status Bar Tooltips
-**Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
-**Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+## 2024-04-20 - VS Code StatusBarItem Accessibility
+**Learning:** VS Code `StatusBarItem` UI elements often rely on terse text strings containing icon shortcodes like `$(shield)` and condensed formatting to fit small screens. Without explicit configuration, screen readers struggle to parse these correctly.
+**Action:** Always provide the `accessibilityInformation` object when creating or dynamically updating VS Code extension `StatusBarItem` elements, ensuring it has a clear, human-readable `label` and appropriate `role` (like 'button' if clickable) to provide a smooth experience for visually impaired users.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -29,6 +29,10 @@ function activate(context) {
   );
   statusBarItem.command = 'specguard.score';
   statusBarItem.tooltip = 'Click to see CDD score details';
+  statusBarItem.accessibilityInformation = {
+    label: 'CDD Score: Unknown',
+    role: 'button'
+  };
   context.subscriptions.push(statusBarItem);
 
   // Diagnostics
@@ -213,6 +217,7 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.accessibilityInformation = { label: 'CDD Score: Unknown', role: 'button' };
       statusBarItem.show();
       return;
     }
@@ -232,6 +237,10 @@ async function refreshScore() {
 
     statusBarItem.text = `${icon} CDD: ${score}/100 (${grade})`;
     statusBarItem.tooltip = `CDD Score: ${score}/100 - ${tooltipStatus}\nClick to see details`;
+    statusBarItem.accessibilityInformation = {
+      label: `CDD Score: ${score} out of 100, Grade ${grade}, Status: ${tooltipStatus}`,
+      role: 'button'
+    };
     statusBarItem.backgroundColor = score < threshold
       ? new vscode.ThemeColor('statusBarItem.warningBackground')
       : undefined;
@@ -243,6 +252,7 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.accessibilityInformation = { label: 'CDD Score: Unknown', role: 'button' };
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
### 💡 What
Added `accessibilityInformation` to the VS Code extension's `StatusBarItem`. It now dynamically updates its spoken label to read out the full CDD score, grade, and status whenever the score changes, instead of relying on the raw UI text which includes unparsed icon shortcodes.

### 🎯 Why
VS Code's status bar is heavily utilized by this extension to display the project's CDD score. When a screen reader parses the raw status bar text like `$(shield) CDD: 85/100 (B)`, it can read aloud the literal syntax or stumble. By providing a clean `accessibilityInformation.label` (e.g., `CDD Score: 85 out of 100, Grade B, Status: Good`), we significantly improve the experience for visually impaired users using the extension.

### 📸 Before/After
**Before:** Screen reader encounters `$(shield) CDD: 85/100 (B)` and tooltip text separately.
**After:** Screen reader directly reads `CDD Score: 85 out of 100, Grade B, Status: Good`, and correctly identifies the item as a button.

### ♿ Accessibility
- Explicitly adds the `accessibilityInformation` object to the `StatusBarItem`.
- Dynamically assigns an English-sentence representation of the score and status.
- Sets the ARIA `role` to `button` so users know it's interactable.

---
*PR created automatically by Jules for task [15337940834891122201](https://jules.google.com/task/15337940834891122201) started by @raccioly*