### PR TITLE
🎨 Palette: [UX improvement] Add accessibilityInformation to VS Code status bar item

### DIFF
--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -29,6 +29,10 @@ function activate(context) {
   );
   statusBarItem.command = 'specguard.score';
   statusBarItem.tooltip = 'Click to see CDD score details';
+  statusBarItem.accessibilityInformation = {
+    label: 'CDD Score: Unknown',
+    role: 'button'
+  };
   context.subscriptions.push(statusBarItem);
 
   // Diagnostics
@@ -213,6 +217,7 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.accessibilityInformation = { label: 'CDD Score: Unknown', role: 'button' };
       statusBarItem.show();
       return;
     }
@@ -232,6 +237,10 @@ async function refreshScore() {
 
     statusBarItem.text = `${icon} CDD: ${score}/100 (${grade})`;
     statusBarItem.tooltip = `CDD Score: ${score}/100 - ${tooltipStatus}\nClick to see details`;
+    statusBarItem.accessibilityInformation = {
+      label: `CDD Score: ${score} out of 100, Grade ${grade}, ${tooltipStatus}`,
+      role: 'button'
+    };
     statusBarItem.backgroundColor = score < threshold
       ? new vscode.ThemeColor('statusBarItem.warningBackground')
       : undefined;
@@ -243,6 +252,7 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.accessibilityInformation = { label: 'CDD Score: Unknown', role: 'button' };
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 **What:** 
Added the `accessibilityInformation` property to the SpecGuard VS Code extension `statusBarItem`. The status bar item now properly announces its role as a `button` and provides explicitly clear, expanded aria-labels replacing the shorthand icon notation during normal operation, unparseable outputs, and error states.

🎯 **Why:** 
The status bar item used shorthand text (e.g. `$(verified) CDD: 90/100 (A)`) combined with visual color cues to display the score and grade. Screen readers often interpret these icons poorly and miss the color context completely, resulting in an inaccessible experience for developers relying on assistive technologies to monitor their code documentation compliance.

📸 **Before/After:**
*Before:*
Screen readers would read the raw text such as `"CDD 90 slash 100 A"`, missing the context of the warning icons or colors.

*After:*
Screen readers will read `"CDD Score: 90 out of 100, Grade A, Excellent, Button"` giving full context to the status visually represented.

♿ **Accessibility:**
* Added explicit descriptive `label` text string interpolation.
* Set explicitly clear `role` as a `"button"` given the clickable nature of the status bar item.

---
*PR created automatically by Jules for task [16800521254397623468](https://jules.google.com/task/16800521254397623468) started by @raccioly*