### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/cli/commands/generate.mjs
+++ b/cli/commands/generate.mjs
@@ -472,7 +472,13 @@ function countFilesAndLines(dir, scan) {
     scan.totalFiles++;
     try {
       const content = readFileSync(filePath, 'utf-8');
-      scan.totalLines += content.split('\n').length;
+      // ⚡ Bolt: Fast line counting using indexOf without allocating string arrays
+      let lines = 1;
+      let pos = -1;
+      while ((pos = content.indexOf('\n', pos + 1)) !== -1) {
+        lines++;
+      }
+      scan.totalLines += lines;
     } catch { /* skip binary files */ }
   });
 }


### PR DESCRIPTION
💡 **What:** Replaced the expensive `content.split('\n').length` string splitting with an efficient string `indexOf` loop for counting lines inside the `countFilesAndLines` function in `cli/commands/generate.mjs`.

🎯 **Why:** Creating string arrays simply to count lines allocates lots of unnecessary memory and forces the garbage collector to work harder, especially when executing on large files during directory traversal. Searching for the newline character `\n` using a while loop completely avoids this memory allocation overhead while achieving exactly the same outcome.

📊 **Impact:** Reduces memory allocation overhead significantly and improves file scanning speeds slightly during the `generate` command, particularly noticeable in massive codebases.

🔬 **Measurement:** Execute `docguard generate` on a large test repository and use `--inspect` to measure node memory heap allocations, confirming lower footprint compared to the previous `split` approach.

---
*PR created automatically by Jules for task [2598532763723626364](https://jules.google.com/task/2598532763723626364) started by @raccioly*