### PR TITLE
🎨 Palette: Add screen reader accessibility to status bar item

### DIFF
--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -29,6 +29,7 @@ function activate(context) {
   );
   statusBarItem.command = 'specguard.score';
   statusBarItem.tooltip = 'Click to see CDD score details';
+  statusBarItem.accessibilityInformation = { label: 'CDD Score: Unknown', role: 'button' };
   context.subscriptions.push(statusBarItem);
 
   // Diagnostics
@@ -213,6 +214,7 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.accessibilityInformation = { label: 'CDD Score: Unknown', role: 'button' };
       statusBarItem.show();
       return;
     }
@@ -232,6 +234,7 @@ async function refreshScore() {
 
     statusBarItem.text = `${icon} CDD: ${score}/100 (${grade})`;
     statusBarItem.tooltip = `CDD Score: ${score}/100 - ${tooltipStatus}\nClick to see details`;
+    statusBarItem.accessibilityInformation = { label: `CDD Score: ${score} out of 100, ${tooltipStatus}`, role: 'button' };
     statusBarItem.backgroundColor = score < threshold
       ? new vscode.ThemeColor('statusBarItem.warningBackground')
       : undefined;
@@ -243,6 +246,7 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.accessibilityInformation = { label: 'CDD Score: Unknown', role: 'button' };
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 **What:** Added `accessibilityInformation` to the VS Code extension's status bar item, both upon creation and during score refresh updates.
🎯 **Why:** The status bar item frequently uses icons (`$(shield)`, `$(verified)`, `$(warning)`) and shorthand text (`CDD: ?`) which are poorly interpreted by screen readers. Adding an explicit, context-aware `accessibilityInformation` label ensures visually impaired developers receive clear, spoken context about their project's CDD score and status.
📸 **Before/After:** No visual changes. Screen readers will now announce things like "CDD Score: 85 out of 100, Good, button" instead of just the literal symbol strings.
♿ **Accessibility:** Greatly improves screen reader experience for the core UI element of the VS Code extension, explicitly tagging its role as a "button" and providing human-readable state updates.

---
*PR created automatically by Jules for task [12434727164546447187](https://jules.google.com/task/12434727164546447187) started by @raccioly*