### PR TITLE
🎨 Palette: [UX improvement] Add accessibilityInformation to VS Code status bar item

### DIFF
--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -29,6 +29,10 @@ function activate(context) {
   );
   statusBarItem.command = 'specguard.score';
   statusBarItem.tooltip = 'Click to see CDD score details';
+  statusBarItem.accessibilityInformation = {
+    label: 'CDD Score: Unknown',
+    role: 'button'
+  };
   context.subscriptions.push(statusBarItem);
 
   // Diagnostics
@@ -213,6 +217,10 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.accessibilityInformation = {
+        label: 'CDD Score: Unknown',
+        role: 'button'
+      };
       statusBarItem.show();
       return;
     }
@@ -232,6 +240,10 @@ async function refreshScore() {
 
     statusBarItem.text = `${icon} CDD: ${score}/100 (${grade})`;
     statusBarItem.tooltip = `CDD Score: ${score}/100 - ${tooltipStatus}\nClick to see details`;
+    statusBarItem.accessibilityInformation = {
+      label: `CDD Score: ${score} out of 100, Grade ${grade}, ${tooltipStatus}`,
+      role: 'button'
+    };
     statusBarItem.backgroundColor = score < threshold
       ? new vscode.ThemeColor('statusBarItem.warningBackground')
       : undefined;
@@ -243,6 +255,10 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.accessibilityInformation = {
+      label: 'CDD Score: Error',
+      role: 'button'
+    };
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 **What:** Added `accessibilityInformation` to the `statusBarItem` in the DocGuard VS Code extension. Screen readers will now announce detailed, context-aware information when focus reaches the status bar instead of just rendering raw icon text or default button values.
🎯 **Why:** To make the extension fully accessible. Before, visual-only users had icon cues and tooltips to understand CDD score thresholds and status. Screen reader users would only get vague generic text.
📸 **Before/After:** Not a visual change. Screen reader announcements were updated.
♿ **Accessibility:** Screen reader users will now be explicitly informed of current CDD scores, thresholds, and states (e.g. `CDD Score: 85 out of 100, Grade B, Good`).

---
*PR created automatically by Jules for task [4802156465389801368](https://jules.google.com/task/4802156465389801368) started by @raccioly*