### PR TITLE
🎨 Palette: [UX improvement] Add accessibilityInformation to VS Code StatusBarItem

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2024-04-16 - Context-Aware Screen Reader Support for Status Bar
+**Learning:** When creating or dynamically updating VS Code extension UI elements like `StatusBarItem`, explicitly set `accessibilityInformation` (with `label` and `role`) to provide clear, up-to-date spoken context for screen readers, especially when the item relies on icons or shorthand text like "$(shield) CDD: ?".
+**Action:** Always provide explicit `accessibilityInformation` on status bar items and ensure it dynamically updates alongside visual states like tooltips and text.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -29,6 +29,7 @@ function activate(context) {
   );
   statusBarItem.command = 'specguard.score';
   statusBarItem.tooltip = 'Click to see CDD score details';
+  statusBarItem.accessibilityInformation = { label: 'CDD Score loading', role: 'button' };
   context.subscriptions.push(statusBarItem);
 
   // Diagnostics
@@ -213,6 +214,7 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.accessibilityInformation = { label: 'CDD Score unknown', role: 'button' };
       statusBarItem.show();
       return;
     }
@@ -235,6 +237,7 @@ async function refreshScore() {
     statusBarItem.backgroundColor = score < threshold
       ? new vscode.ThemeColor('statusBarItem.warningBackground')
       : undefined;
+    statusBarItem.accessibilityInformation = { label: `CDD Score: ${score} out of 100, ${tooltipStatus}`, role: 'button' };
     statusBarItem.show();
 
     // Run diagnostics
@@ -243,6 +246,7 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.accessibilityInformation = { label: 'CDD Score unknown', role: 'button' };
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
### 💡 What
Added `accessibilityInformation` (with explicit `label` and `role` properties) to the SpecGuard VS Code extension's `StatusBarItem`.

### 🎯 Why
The status bar heavily relies on icons (`$(shield)`, `$(warning)`, etc.) and shorthand text (`CDD: 60/100`) to communicate the project's documentation health. This causes friction for developers using screen readers, who may only hear confusing punctuation or miss context completely. By providing dynamic accessibility labels that track the tooltip text, the status bar becomes universally usable.

### 📸 Before/After
**Before:** Screen reader announces something akin to "Button, Shield C D D Question mark" or "Button, pass C D D 80 out of 100".
**After:** Screen reader accurately announces the full context, such as "Button, CDD Score unknown" or "Button, CDD Score: 80 out of 100, Good".

### ♿ Accessibility
This change ensures WCAG compliance within the IDE by bridging the gap between visual state cues (tooltips and colors) and semantic structure (`accessibilityInformation`) in VS Code's status bar APIs.

---
*PR created automatically by Jules for task [4516951091836834324](https://jules.google.com/task/4516951091836834324) started by @raccioly*