### PR TITLE
⚡ Bolt: [performance improvement] Avoid array allocation during line counting

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - [Optimization]
 **Learning:** Found string.includes early return could speed up checkUntrackedTodos in cli/validators/todo-tracking.mjs.
 **Action:** Implement fast early return with includes check before doing expensive splitting or matching.
+## 2024-05-18 - [Optimization - Memory Allocation]
+**Learning:** Found that counting lines with `content.split('\n').length` in a file read block causes unnecessary array allocation and GC overhead for large files.
+**Action:** Use a `while` loop with `String.prototype.indexOf('\n')` to count lines instead to optimize memory and speed when scanning large files.

--- a/cli/commands/generate.mjs
+++ b/cli/commands/generate.mjs
@@ -472,7 +472,15 @@ function countFilesAndLines(dir, scan) {
     scan.totalFiles++;
     try {
       const content = readFileSync(filePath, 'utf-8');
-      scan.totalLines += content.split('\n').length;
+
+      // Optimize line counting by avoiding string splitting and array allocation
+      let lineCount = 1;
+      let pos = content.indexOf('\n');
+      while (pos !== -1) {
+        lineCount++;
+        pos = content.indexOf('\n', pos + 1);
+      }
+      scan.totalLines += lineCount;
     } catch { /* skip binary files */ }
   });
 }


### PR DESCRIPTION
### 💡 What
Replaced `content.split('\n').length` with a `while` loop using `indexOf('\n')` in `cli/commands/generate.mjs`'s `countFilesAndLines` function.

### 🎯 Why
When running the `generate` command (which scans all files), the old method split entire file contents into massive arrays of strings just to count the length of the array. This resulted in excessive memory allocation and heavy garbage collection overhead, particularly for large monolithic codebases or large files.

### 📊 Impact
- Substantially reduces memory footprint during `docguard generate` command execution.
- Speeds up file processing, as scanning characters via `indexOf` is significantly faster than allocating and creating a string array.

### 🔬 Measurement
Run `pnpm test` to ensure that line counting behavior remains identically correct without regressions. Profile `docguard generate` on a large test codebase to observe decreased memory allocation during the filesystem scan.

---
*PR created automatically by Jules for task [2789326584170083443](https://jules.google.com/task/2789326584170083443) started by @raccioly*