### PR TITLE
⚡ Bolt: Optimize line counting to reduce memory allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - [Optimization]
 **Learning:** Found string.includes early return could speed up checkUntrackedTodos in cli/validators/todo-tracking.mjs.
 **Action:** Implement fast early return with includes check before doing expensive splitting or matching.
+
+## 2026-04-25 - [Line Counting Optimization]
+**Learning:** `split('\n').length` allocates unnecessary string arrays just to count lines, which adds significant memory and processing overhead when scanning large codebases (e.g., in `generate.mjs`).
+**Action:** Use a `while` loop with `indexOf('\n', pos)` instead to count lines efficiently without extra allocation.

--- a/cli/commands/generate.mjs
+++ b/cli/commands/generate.mjs
@@ -472,7 +472,14 @@ function countFilesAndLines(dir, scan) {
     scan.totalFiles++;
     try {
       const content = readFileSync(filePath, 'utf-8');
-      scan.totalLines += content.split('\n').length;
+
+      // Performance optimization: Count lines without allocating an array
+      let lines = 1;
+      let pos = -1;
+      while ((pos = content.indexOf('\n', pos + 1)) !== -1) {
+        lines++;
+      }
+      scan.totalLines += lines;
     } catch { /* skip binary files */ }
   });
 }


### PR DESCRIPTION
### 💡 What
Replaced `content.split('\n').length` with a `while` loop utilizing `indexOf('\n')` inside `countFilesAndLines` in `cli/commands/generate.mjs`.

### 🎯 Why
Using `split('\n').length` to count lines forces V8 to allocate a full array of strings in memory. For large files or entire codebases scanned during `generate`, this causes significant memory allocation and garbage collection overhead. Using `indexOf` traverses the string and counts line breaks efficiently without allocating an array.

### 📊 Impact
Reduces peak memory usage and garbage collection frequency during `docguard generate` executions across large codebases.

### 🔬 Measurement
Run `pnpm test` to verify functionality remains unchanged. You can measure memory consumption running the generator on a very large codebase.

---
*PR created automatically by Jules for task [17551848891452694378](https://jules.google.com/task/17551848891452694378) started by @raccioly*