### PR TITLE
🎨 Palette: Add screen reader accessibility to status bar item

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2024-04-16 - Screen Reader Accessibility in VS Code Extensions
+**Learning:** VS Code extension Status Bar Items rely heavily on icons and shorthand text (e.g., `$(shield) CDD: ?`). Screen readers struggle to parse these correctly. Setting the `accessibilityInformation` property with a descriptive `label` and a `role` ensures visually impaired developers receive full context.
+**Action:** Always include `accessibilityInformation` when creating or modifying dynamic VS Code UI elements like `StatusBarItem`.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -29,6 +29,10 @@ function activate(context) {
   );
   statusBarItem.command = 'specguard.score';
   statusBarItem.tooltip = 'Click to see CDD score details';
+  statusBarItem.accessibilityInformation = {
+    label: 'Canonical Driven Development score is currently unknown',
+    role: 'button'
+  };
   context.subscriptions.push(statusBarItem);
 
   // Diagnostics
@@ -213,6 +217,10 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.accessibilityInformation = {
+        label: 'Canonical Driven Development score could not be determined',
+        role: 'button'
+      };
       statusBarItem.show();
       return;
     }
@@ -232,6 +240,10 @@ async function refreshScore() {
 
     statusBarItem.text = `${icon} CDD: ${score}/100 (${grade})`;
     statusBarItem.tooltip = `CDD Score: ${score}/100 - ${tooltipStatus}\nClick to see details`;
+    statusBarItem.accessibilityInformation = {
+      label: `Canonical Driven Development score is ${score} out of 100, grade ${grade}. Status is ${tooltipStatus}.`,
+      role: 'button'
+    };
     statusBarItem.backgroundColor = score < threshold
       ? new vscode.ThemeColor('statusBarItem.warningBackground')
       : undefined;
@@ -243,6 +255,10 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.accessibilityInformation = {
+      label: 'Canonical Driven Development score failed to load due to an error',
+      role: 'button'
+    };
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 What: Added the `accessibilityInformation` object to the `statusBarItem` in the VS Code extension, covering initialization, successful fetch, failure, and error states.
🎯 Why: To provide full context for screen readers parsing dynamic shorthand text and icons on the VS Code status bar.
📸 Before/After: Visual UI unchanged, but screen readers now read informative labels rather than disjointed icons.
♿ Accessibility: Directly targets accessibility for visually impaired developers relying on screen readers.

---
*PR created automatically by Jules for task [3659730105104663449](https://jules.google.com/task/3659730105104663449) started by @raccioly*