### PR TITLE
🎨 Palette: Add accessibility info to status bar item

### DIFF
--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -29,6 +29,7 @@ function activate(context) {
   );
   statusBarItem.command = 'specguard.score';
   statusBarItem.tooltip = 'Click to see CDD score details';
+  statusBarItem.accessibilityInformation = { label: 'CDD Score: Unknown', role: 'button' };
   context.subscriptions.push(statusBarItem);
 
   // Diagnostics
@@ -213,6 +214,7 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.accessibilityInformation = { label: 'CDD Score: Unknown', role: 'button' };
       statusBarItem.show();
       return;
     }
@@ -232,6 +234,7 @@ async function refreshScore() {
 
     statusBarItem.text = `${icon} CDD: ${score}/100 (${grade})`;
     statusBarItem.tooltip = `CDD Score: ${score}/100 - ${tooltipStatus}\nClick to see details`;
+    statusBarItem.accessibilityInformation = { label: `CDD Score: ${score} out of 100, ${tooltipStatus}`, role: 'button' };
     statusBarItem.backgroundColor = score < threshold
       ? new vscode.ThemeColor('statusBarItem.warningBackground')
       : undefined;
@@ -243,6 +246,7 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.accessibilityInformation = { label: 'CDD Score: Error', role: 'button' };
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 **What**: Added `accessibilityInformation` to the SpecGuard VS Code extension's status bar item. The information updates dynamically alongside the visual status to reflect the correct state (e.g., Score, Unknown, Error).
🎯 **Why**: When visually impaired users navigate VS Code via screen reader, a status bar item that relies on an icon and a terse string ("$(shield) CDD: 80/100") is often poorly read. By explicitly defining the `label` and setting `role: 'button'`, the screen reader provides full, helpful context when the item is focused.
📸 **Before/After**: N/A - Visuals are unchanged; purely an accessibility enhancement.
♿ **Accessibility**: Provides robust screen-reader support using VS Code's official accessibility API (`accessibilityInformation`), directly linking the visual state (score, warnings, errors) to descriptive spoken text.

---
*PR created automatically by Jules for task [13023951127452013586](https://jules.google.com/task/13023951127452013586) started by @raccioly*