### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Found multiple instances where user-controlled inputs (`projectDir`, `filePath`) were interpolated directly into shell commands via `execSync` (e.g., `execSync(\`node "\${cliPath}" init --dir "\${projectDir}"\`)`).
 **Learning:** This is a classic command injection vulnerability. If `projectDir` contains shell metacharacters like `;`, `&&`, or `||`, it allows arbitrary command execution.
 **Prevention:** Always use `execFileSync` (or `execFile` for async) instead of `execSync` when executing commands with dynamic inputs. Pass arguments as an array to ensure they are passed directly to the executable without shell interpolation.
+
+## 2026-04-27 - [Command Injection via execSync in VS Code Extension]
+**Vulnerability:** The `execSpecguard` function in `vscode-extension/extension.js` used `execSync` and string-based command construction (e.g., `cmd = \"npx -y specguard ${args}\"`), which can lead to command injection if arguments are manipulated, and option injection.
+**Learning:** Command construction with strings using `execSync` can lead to shell evaluation of user inputs and path exploits in a VSCode environment context where workspaces can contain untrusted code. Additionally, resolving binaries correctly across OSes (like `npx.cmd` on Windows) is essential for cross-platform compatibility when transitioning to `execFileSync`.
+**Prevention:** Use `execFileSync` and pass argument lists as an array to avoid shell interpretation and bypass option injection. Resolve binaries and command wrappers securely based on the current platform.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -9,7 +9,7 @@
  */
 
 const vscode = require('vscode');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
@@ -20,7 +20,7 @@ let fileWatcher;
 
 // ── Activation ─────────────────────────────────────────────────────────────
 
-function activate(context) {
+async function activate(context) {
   outputChannel = vscode.window.createOutputChannel('SpecGuard');
 
   // Status bar
@@ -172,32 +172,43 @@ function getNodePath() {
 
 function findSpecguard(workspaceDir) {
   // Check local node_modules first
-  const localBin = path.join(workspaceDir, 'node_modules', '.bin', 'specguard');
+  const isWin = process.platform === 'win32';
+  const binName = isWin ? 'specguard.cmd' : 'specguard';
+  const localBin = path.join(workspaceDir, 'node_modules', '.bin', binName);
   if (fs.existsSync(localBin)) return localBin;
 
   // Try npx
   return null;
 }
 
-function execSpecguard(workspaceDir, args) {
+function execSpecguard(workspaceDir, argsArray) {
   const localBin = findSpecguard(workspaceDir);
+  const isWin = process.platform === 'win32';
 
-  let cmd;
+  let execPath;
+  let finalArgs;
+
   if (localBin) {
-    cmd = `"${localBin}" ${args}`;
+    execPath = localBin;
+    finalArgs = argsArray;
   } else {
-    cmd = `npx -y specguard ${args}`;
+    execPath = isWin ? 'npx.cmd' : 'npx';
+    finalArgs = ['-y', 'specguard', ...argsArray];
   }
 
   try {
-    return execSync(cmd, {
+    return execFileSync(execPath, finalArgs, {
       cwd: workspaceDir,
       encoding: 'utf-8',
       env: { ...process.env, NO_COLOR: '1' },
       timeout: 30000,
+      stdio: 'pipe'
     });
   } catch (e) {
     outputChannel.appendLine(`SpecGuard error: ${e.message}`);
+    if (e.stderr) {
+      outputChannel.appendLine(`stderr: ${e.stderr}`);
+    }
     return e.stdout || '';
   }
 }
@@ -209,7 +220,7 @@ async function refreshScore() {
   if (!dir) return;
 
   try {
-    const output = execSpecguard(dir, 'score --format json');
+    const output = execSpecguard(dir, ['score', '--format', 'json']);
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
@@ -362,7 +373,7 @@ function runCommand(cmd) {
   outputChannel.show(true);
   outputChannel.appendLine(`$ specguard ${cmd}\n`);
 
-  const output = execSpecguard(dir, cmd);
+  const output = execSpecguard(dir, [cmd]);
   outputChannel.appendLine(output);
 }
 
@@ -374,7 +385,7 @@ async function runGuard() {
   outputChannel.show(true);
   outputChannel.appendLine('$ specguard guard\n');
 
-  const output = execSpecguard(dir, 'guard');
+  const output = execSpecguard(dir, ['guard']);
   outputChannel.appendLine(output);
 
   await runDiagnosticsAsync(dir);
@@ -403,11 +414,11 @@ function runFixCommand() {
   outputChannel.show(true);
   outputChannel.appendLine('$ specguard fix\n');
 
-  const output = execSpecguard(dir, 'fix');
+  const output = execSpecguard(dir, ['fix']);
   outputChannel.appendLine(output);
 
   // Also get the AI prompt version
-  const promptOutput = execSpecguard(dir, 'fix --format prompt');
+  const promptOutput = execSpecguard(dir, ['fix', '--format', 'prompt']);
 
   if (promptOutput && !promptOutput.includes('No CDD issues found')) {
     // Offer to copy AI prompt to clipboard
@@ -438,7 +449,7 @@ async function runFixAuto() {
   outputChannel.show(true);
   outputChannel.appendLine('$ specguard fix --auto\n');
 
-  const output = execSpecguard(dir, 'fix --auto');
+  const output = execSpecguard(dir, ['fix', '--auto']);
   outputChannel.appendLine(output);
 
   await refreshScore();
@@ -462,7 +473,7 @@ function runBadge() {
   const dir = getWorkspaceDir();
   if (!dir) return;
 
-  const output = execSpecguard(dir, 'badge --format json');
+  const output = execSpecguard(dir, ['badge', '--format', 'json']);
   const jsonStart = output.indexOf('{');
   if (jsonStart < 0) {
     vscode.window.showErrorMessage('SpecGuard: Could not generate badges');
@@ -491,7 +502,7 @@ async function runInit() {
   outputChannel.show(true);
   outputChannel.appendLine('$ specguard init\n');
 
-  const output = execSpecguard(dir, 'init');
+  const output = execSpecguard(dir, ['init']);
   outputChannel.appendLine(output);
 
   await refreshScore();


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `execSpecguard` function in `vscode-extension/extension.js` used `execSync` and constructed commands using template strings (e.g., ``cmd = `npx -y specguard ${args}` ``). This approach allows a malicious workspace to inject arbitrary shell commands or option flags through manipulated `args`.
🎯 Impact: Remote Code Execution (RCE) via command injection if an attacker crafts malicious workspace input or paths that are interpolated into the command string.
🔧 Fix: Refactored `execSpecguard` to use `execFileSync` instead. Converted command strings to arrays of arguments, bypassing the shell. Also securely resolved binaries (`npx.cmd`, `specguard.cmd`) for Windows compatibility without relying on the shell, and updated all call sites to pass argument arrays instead of strings. Added error stderr logging. Fixed existing syntax error where `activate` wasn't `async` despite awaiting `refreshScore()`.
✅ Verification: Ran `pnpm test` successfully. Verified using `node -c` that there are no syntax errors. Logged learnings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [13483677425887566425](https://jules.google.com/task/13483677425887566425) started by @raccioly*