### PR TITLE
🛡️ Sentinel: [HIGH] Fix Command Injection via execSync in VSCode extension

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Found multiple instances where user-controlled inputs (`projectDir`, `filePath`) were interpolated directly into shell commands via `execSync` (e.g., `execSync(\`node "\${cliPath}" init --dir "\${projectDir}"\`)`).
 **Learning:** This is a classic command injection vulnerability. If `projectDir` contains shell metacharacters like `;`, `&&`, or `||`, it allows arbitrary command execution.
 **Prevention:** Always use `execFileSync` (or `execFile` for async) instead of `execSync` when executing commands with dynamic inputs. Pass arguments as an array to ensure they are passed directly to the executable without shell interpolation.
+
+## 2025-05-18 - [Command Injection via execSync in VSCode extension]
+**Vulnerability:** Found `execSync` used with string interpolation (`cmd = \`"${localBin}" ${args}\``) in `vscode-extension/extension.js`. This allows command injection if `args` or the workspace path contains shell metacharacters.
+**Learning:** Node.js extensions executing CLI wrappers often concatenate strings to build shell commands. Because `execSync` executes in a shell by default, this creates a high-severity command injection vulnerability if any part of the path or arguments is untrusted.
+**Prevention:** Always use `execFileSync` instead of `execSync` in extensions. Pass arguments as an explicit array, which bypasses shell interpolation. Handle `.cmd` suffixes for cross-platform execution explicitly instead of relying on the shell to resolve them.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -9,7 +9,7 @@
  */
 
 const vscode = require('vscode');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
@@ -20,7 +20,7 @@ let fileWatcher;
 
 // ── Activation ─────────────────────────────────────────────────────────────
 
-function activate(context) {
+async function activate(context) {
   outputChannel = vscode.window.createOutputChannel('SpecGuard');
 
   // Status bar
@@ -182,20 +182,40 @@ function findSpecguard(workspaceDir) {
 function execSpecguard(workspaceDir, args) {
   const localBin = findSpecguard(workspaceDir);
 
-  let cmd;
-  if (localBin) {
-    cmd = `"${localBin}" ${args}`;
-  } else {
-    cmd = `npx -y specguard ${args}`;
-  }
+  // Parse arguments array carefully considering quotes if any.
+  // Using a simple split for standard known args since we pass them predictably.
+  const matchResult = args.match(/(?:[^\s"]+|"[^"]*")+/g);
+  const argsArray = matchResult ? matchResult.map(arg => arg.replace(/^"|"$/g, '')) : [];
+
+  const options = {
+    cwd: workspaceDir,
+    encoding: 'utf-8',
+    env: { ...process.env, NO_COLOR: '1' },
+    timeout: 30000,
+    stdio: 'pipe'
+  };
 
   try {
-    return execSync(cmd, {
-      cwd: workspaceDir,
-      encoding: 'utf-8',
-      env: { ...process.env, NO_COLOR: '1' },
-      timeout: 30000,
-    });
+    if (localBin) {
+      try {
+        return execFileSync(localBin, argsArray, options);
+      } catch (err) {
+        if (err.code === 'ENOENT' && process.platform === 'win32') {
+          return execFileSync(localBin + '.cmd', argsArray, options);
+        }
+        throw err;
+      }
+    } else {
+      const npxArgs = ['-y', 'specguard', ...argsArray];
+      try {
+        return execFileSync('npx', npxArgs, options);
+      } catch (err) {
+        if (err.code === 'ENOENT' && process.platform === 'win32') {
+          return execFileSync('npx.cmd', npxArgs, options);
+        }
+        throw err;
+      }
+    }
   } catch (e) {
     outputChannel.appendLine(`SpecGuard error: ${e.message}`);
     return e.stdout || '';


### PR DESCRIPTION
**Severity**: HIGH
**Vulnerability**: Command Injection via `execSync`
**Impact**: If the `args` string or the workspace path evaluated in `vscode-extension/extension.js` contained shell metacharacters, an attacker could execute arbitrary commands via the VSCode extension.
**Fix**: Refactored `execSpecguard` to use `execFileSync` and parse the string argument into an explicit array, which bypasses the shell execution entirely.
**Verification**: Tests run cleanly and manual verification of the file changes confirms the use of `execFileSync`.

---
*PR created automatically by Jules for task [15943510327128595322](https://jules.google.com/task/15943510327128595322) started by @raccioly*