### PR TITLE
🎨 Palette: Add dynamic accessibility labels to status bar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+## 2026-04-18 - Dynamic Accessibility Labels on VS Code Status Bar
+**Learning:** For VS Code extension UI elements like `StatusBarItem`, dynamic properties (icon, text, backgroundColor) are typically mapped to informative tooltips. However, standard tooltips are visual. For screen readers, it's critical to dynamically set `accessibilityInformation` (with `label` and `role`) rather than relying on static text, providing context-aware spoken text (like spelling out scores or statuses) whenever the visual state changes.
+**Action:** When creating or dynamically updating VS Code extension UI elements, explicitly update `accessibilityInformation.label` alongside visual changes to ensure screen readers receive equivalent, contextual feedback.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -29,6 +29,10 @@ function activate(context) {
   );
   statusBarItem.command = 'specguard.score';
   statusBarItem.tooltip = 'Click to see CDD score details';
+  statusBarItem.accessibilityInformation = {
+    label: 'CDD Score: Unknown',
+    role: 'button'
+  };
   context.subscriptions.push(statusBarItem);
 
   // Diagnostics
@@ -213,6 +217,10 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.accessibilityInformation = {
+        label: 'CDD Score: Unknown',
+        role: 'button'
+      };
       statusBarItem.show();
       return;
     }
@@ -235,6 +243,10 @@ async function refreshScore() {
     statusBarItem.backgroundColor = score < threshold
       ? new vscode.ThemeColor('statusBarItem.warningBackground')
       : undefined;
+    statusBarItem.accessibilityInformation = {
+      label: `CDD Score: ${score} out of 100, Grade ${grade}, ${tooltipStatus}`,
+      role: 'button'
+    };
     statusBarItem.show();
 
     // Run diagnostics
@@ -243,6 +255,10 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.accessibilityInformation = {
+      label: 'CDD Score: Error',
+      role: 'button'
+    };
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 What: Added dynamic `accessibilityInformation` (label and role) to the VS Code extension's `StatusBarItem`.
🎯 Why: Screen reader users relying on the DocGuard extension previously only received the visual icon and text representation (e.g., "$(pass) CDD: 85/100 (B)"). The newly added explicit accessibility labels provide context-aware spoken text (e.g., "CDD Score: 85 out of 100, Grade B, Good") whenever the status updates.
📸 Before/After: Visual UI is unaffected; screen reader output changes from implicit visual text to explicit contextual labels.
♿ Accessibility: Ensures that dynamic changes to the status bar score, status warnings, and error fallbacks are fully communicated via the Accessibility API.

---
*PR created automatically by Jules for task [9861228181979187964](https://jules.google.com/task/9861228181979187964) started by @raccioly*