### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in execSpecguard

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Found multiple instances where user-controlled inputs (`projectDir`, `filePath`) were interpolated directly into shell commands via `execSync` (e.g., `execSync(\`node "\${cliPath}" init --dir "\${projectDir}"\`)`).
 **Learning:** This is a classic command injection vulnerability. If `projectDir` contains shell metacharacters like `;`, `&&`, or `||`, it allows arbitrary command execution.
 **Prevention:** Always use `execFileSync` (or `execFile` for async) instead of `execSync` when executing commands with dynamic inputs. Pass arguments as an array to ensure they are passed directly to the executable without shell interpolation.
+## 2025-05-18 - [Command Injection via execSync in VS Code Extension]
+**Vulnerability:** Found `execSpecguard` in `vscode-extension/extension.js` using `execSync` with unsanitized inputs. When passing `cmd` with spaces like `"diagnose --fix"`, a simplistic array approach (`[cmd]`) fails because the CLI expects arguments to be split.
+**Learning:** Fixing command injection involves both switching to `execFileSync` and correctly splitting argument strings. Blindly wrapping a space-separated command string in an array (e.g. `['diagnose --fix']`) treats it as a single invalid argument, causing regressions.
+**Prevention:** Always `split(' ')` multi-word command arguments before passing to `execFileSync`, or better yet, refactor callers to natively pass arrays instead of concatenated strings.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -9,7 +9,7 @@
  */
 
 const vscode = require('vscode');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
@@ -20,7 +20,7 @@ let fileWatcher;
 
 // ── Activation ─────────────────────────────────────────────────────────────
 
-function activate(context) {
+async function activate(context) {
   outputChannel = vscode.window.createOutputChannel('SpecGuard');
 
   // Status bar
@@ -171,34 +171,41 @@ function getNodePath() {
 }
 
 function findSpecguard(workspaceDir) {
+  const isWindows = process.platform === 'win32';
   // Check local node_modules first
-  const localBin = path.join(workspaceDir, 'node_modules', '.bin', 'specguard');
+  const localBin = path.join(workspaceDir, 'node_modules', '.bin', isWindows ? 'specguard.cmd' : 'specguard');
   if (fs.existsSync(localBin)) return localBin;
 
   // Try npx
   return null;
 }
 
-function execSpecguard(workspaceDir, args) {
+function execSpecguard(workspaceDir, argsArray) {
   const localBin = findSpecguard(workspaceDir);
 
   let cmd;
+  let finalArgs;
+  const isWindows = process.platform === 'win32';
+
   if (localBin) {
-    cmd = `"${localBin}" ${args}`;
+    cmd = localBin;
+    finalArgs = argsArray;
   } else {
-    cmd = `npx -y specguard ${args}`;
+    cmd = isWindows ? 'npx.cmd' : 'npx';
+    finalArgs = ['-y', 'specguard', ...argsArray];
   }
 
   try {
-    return execSync(cmd, {
+    return execFileSync(cmd, finalArgs, {
       cwd: workspaceDir,
       encoding: 'utf-8',
       env: { ...process.env, NO_COLOR: '1' },
       timeout: 30000,
+      stdio: ['pipe', 'pipe', 'pipe']
     });
   } catch (e) {
     outputChannel.appendLine(`SpecGuard error: ${e.message}`);
-    return e.stdout || '';
+    return e.stdout || e.stderr || '';
   }
 }
 
@@ -209,7 +216,7 @@ async function refreshScore() {
   if (!dir) return;
 
   try {
-    const output = execSpecguard(dir, 'score --format json');
+    const output = execSpecguard(dir, ['score', '--format', 'json']);
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
@@ -362,7 +369,8 @@ function runCommand(cmd) {
   outputChannel.show(true);
   outputChannel.appendLine(`$ specguard ${cmd}\n`);
 
-  const output = execSpecguard(dir, cmd);
+  const cmdArgs = cmd.split(' ');
+  const output = execSpecguard(dir, cmdArgs);
   outputChannel.appendLine(output);
 }
 
@@ -374,7 +382,7 @@ async function runGuard() {
   outputChannel.show(true);
   outputChannel.appendLine('$ specguard guard\n');
 
-  const output = execSpecguard(dir, 'guard');
+  const output = execSpecguard(dir, ['guard']);
   outputChannel.appendLine(output);
 
   await runDiagnosticsAsync(dir);
@@ -403,11 +411,11 @@ function runFixCommand() {
   outputChannel.show(true);
   outputChannel.appendLine('$ specguard fix\n');
 
-  const output = execSpecguard(dir, 'fix');
+  const output = execSpecguard(dir, ['fix']);
   outputChannel.appendLine(output);
 
   // Also get the AI prompt version
-  const promptOutput = execSpecguard(dir, 'fix --format prompt');
+  const promptOutput = execSpecguard(dir, ['fix', '--format', 'prompt']);
 
   if (promptOutput && !promptOutput.includes('No CDD issues found')) {
     // Offer to copy AI prompt to clipboard
@@ -438,7 +446,7 @@ async function runFixAuto() {
   outputChannel.show(true);
   outputChannel.appendLine('$ specguard fix --auto\n');
 
-  const output = execSpecguard(dir, 'fix --auto');
+  const output = execSpecguard(dir, ['fix', '--auto']);
   outputChannel.appendLine(output);
 
   await refreshScore();
@@ -462,7 +470,7 @@ function runBadge() {
   const dir = getWorkspaceDir();
   if (!dir) return;
 
-  const output = execSpecguard(dir, 'badge --format json');
+  const output = execSpecguard(dir, ['badge', '--format', 'json']);
   const jsonStart = output.indexOf('{');
   if (jsonStart < 0) {
     vscode.window.showErrorMessage('SpecGuard: Could not generate badges');
@@ -491,7 +499,7 @@ async function runInit() {
   outputChannel.show(true);
   outputChannel.appendLine('$ specguard init\n');
 
-  const output = execSpecguard(dir, 'init');
+  const output = execSpecguard(dir, ['init']);
   outputChannel.appendLine(output);
 
   await refreshScore();


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: `execSync` used to execute shell commands with unsanitized `workspaceDir` and `args` variables, allowing arbitrary command execution if the workspace directory contains shell metacharacters.
🎯 Impact: Remote Code Execution (RCE) via command injection if a user opens a maliciously crafted workspace.
🔧 Fix: Replaced `execSync` with `execFileSync` and changed `execSpecguard` to accept an array of arguments, bypassing shell interpolation entirely. Implemented explicit `.cmd` check for Windows execution.
✅ Verification: Ran unit tests (`pnpm test`) and syntax validation on `vscode-extension/extension.js` (`node -c`). Verify visually by ensuring SpecGuard runs properly using the extension.

---
*PR created automatically by Jules for task [12623336146297469708](https://jules.google.com/task/12623336146297469708) started by @raccioly*