### PR TITLE
🎨 Palette: [UX improvement] Add Accessibility Info to VS Code StatusBarItem

### DIFF
--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -20,7 +20,7 @@ let fileWatcher;
 
 // ── Activation ─────────────────────────────────────────────────────────────
 
-function activate(context) {
+async function activate(context) {
   outputChannel = vscode.window.createOutputChannel('SpecGuard');
 
   // Status bar
@@ -29,6 +29,10 @@ function activate(context) {
   );
   statusBarItem.command = 'specguard.score';
   statusBarItem.tooltip = 'Click to see CDD score details';
+  statusBarItem.accessibilityInformation = {
+    label: 'CDD Score: Unknown',
+    role: 'button'
+  };
   context.subscriptions.push(statusBarItem);
 
   // Diagnostics
@@ -213,6 +217,10 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.accessibilityInformation = {
+        label: 'CDD Score: Unknown',
+        role: 'button'
+      };
       statusBarItem.show();
       return;
     }
@@ -232,6 +240,10 @@ async function refreshScore() {
 
     statusBarItem.text = `${icon} CDD: ${score}/100 (${grade})`;
     statusBarItem.tooltip = `CDD Score: ${score}/100 - ${tooltipStatus}\nClick to see details`;
+    statusBarItem.accessibilityInformation = {
+      label: `CDD Score: ${score} out of 100, ${tooltipStatus}`,
+      role: 'button'
+    };
     statusBarItem.backgroundColor = score < threshold
       ? new vscode.ThemeColor('statusBarItem.warningBackground')
       : undefined;
@@ -243,6 +255,10 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.accessibilityInformation = {
+      label: 'CDD Score: Error or Unknown',
+      role: 'button'
+    };
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
### 💡 What
Added `accessibilityInformation` to the VS Code `StatusBarItem` to provide meaningful voice feedback for screen readers during initialization and subsequent data refreshes. The `activate` function was safely updated to `async`.

### 🎯 Why
VS Code `StatusBarItem` objects without explicit `accessibilityInformation` read out poorly on screen readers, especially when they utilize visual icons (like `$(shield)`) or shorthand textual representations (`CDD: ?`). This ensures developers relying on screen readers receive clear context regarding their Canonical-Driven Development score without visual dependency.

### 📸 Before/After
**Before:** Screen reader would read the raw text: `"$(shield) CDD: ?"` or `"$(pass) CDD: 85/100 (B)"`.
**After:** Screen reader will read: `"CDD Score: Unknown"` or `"CDD Score: 85 out of 100, Good"`.

### ♿ Accessibility
- Added `role: 'button'` to clearly define the UI element interactability.
- Dynamically mapped visual states (`tooltipStatus`) and scores to a human-readable spoken `label`.
- Updated error and pending states to provide clear "Unknown" or "Error" verbal feedback.

---
*PR created automatically by Jules for task [10616416875242864639](https://jules.google.com/task/10616416875242864639) started by @raccioly*