### PR TITLE
🎨 Palette: Add accessibility info to Status Bar Item

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+## 2024-05-01 - Add accessibility info to Status Bar Item
+**Learning:** When using VS Code `StatusBarItem` with shorthand icons and text, it lacks context for screen readers. Explicitly setting `accessibilityInformation` (with `label` and `role`) is crucial for providing clear spoken context.
+**Action:** Always set `accessibilityInformation` when creating or dynamically updating VS Code extension UI elements like `StatusBarItem`, especially when the item relies on icons or shorthand text. Update it synchronously alongside `text` and `tooltip` changes.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -20,7 +20,7 @@ let fileWatcher;
 
 // ── Activation ─────────────────────────────────────────────────────────────
 
-function activate(context) {
+async function activate(context) {
   outputChannel = vscode.window.createOutputChannel('SpecGuard');
 
   // Status bar
@@ -29,6 +29,10 @@ function activate(context) {
   );
   statusBarItem.command = 'specguard.score';
   statusBarItem.tooltip = 'Click to see CDD score details';
+  statusBarItem.accessibilityInformation = {
+    label: 'CDD Score',
+    role: 'button'
+  };
   context.subscriptions.push(statusBarItem);
 
   // Diagnostics
@@ -213,6 +217,11 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.tooltip = 'CDD Score: Unknown\nClick to see details';
+      statusBarItem.accessibilityInformation = {
+        label: 'CDD Score: Unknown',
+        role: 'button'
+      };
       statusBarItem.show();
       return;
     }
@@ -232,6 +241,10 @@ async function refreshScore() {
 
     statusBarItem.text = `${icon} CDD: ${score}/100 (${grade})`;
     statusBarItem.tooltip = `CDD Score: ${score}/100 - ${tooltipStatus}\nClick to see details`;
+    statusBarItem.accessibilityInformation = {
+      label: `CDD Score is ${score} out of 100. Status: ${tooltipStatus}`,
+      role: 'button'
+    };
     statusBarItem.backgroundColor = score < threshold
       ? new vscode.ThemeColor('statusBarItem.warningBackground')
       : undefined;
@@ -243,6 +256,11 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.tooltip = 'CDD Score: Error\nClick to see details';
+    statusBarItem.accessibilityInformation = {
+      label: 'CDD Score: Error',
+      role: 'button'
+    };
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
**💡 What**
Added explicit `accessibilityInformation` (with `label` and `role`) to the VS Code `StatusBarItem` that displays the CDD Score. It now dynamically updates the spoken label for screen readers whenever the score is refreshed or an error occurs.

**🎯 Why**
The CDD score status bar item relied on shorthand text (like `$(shield) CDD: 85/100`) and icons to convey state. Without explicit accessibility information, screen readers lack the full context of what the item represents and what the different states mean.

**📸 Before/After**
*Before:* Screen reader reads "shield CDD 85 slash 100".
*After:* Screen reader reads "CDD Score is 85 out of 100. Status: Good" (button).

**♿ Accessibility**
- Set `role: 'button'` to clarify interactive capability.
- Added dynamic `label` that translates the shorthand score and icons into descriptive natural language for screen readers.

---
*PR created automatically by Jules for task [12294168167698730707](https://jules.google.com/task/12294168167698730707) started by @raccioly*