### PR TITLE
⚡ Bolt: [performance improvement] Avoid N^2 lowercasing in todo-tracking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - [Optimization]
 **Learning:** Found string.includes early return could speed up checkUntrackedTodos in cli/validators/todo-tracking.mjs.
 **Action:** Implement fast early return with includes check before doing expensive splitting or matching.
+
+## 2025-05-01 - [Optimization: Avoid Redundant Operations in Nested Loops]
+**Learning:** Found N^2 performance bottlenecks in nested loops (such as comparing a list of TODOs against multiple tracking documents). Calling expensive string operations like `.toLowerCase()` inside these loops drastically reduces performance.
+**Action:** Precompute expensive operations during the initial file load or mapping phase and store the result (e.g. `contentLower` on the document object) to avoid recalculating the same value repetitively.

--- a/cli/validators/todo-tracking.mjs
+++ b/cli/validators/todo-tracking.mjs
@@ -185,17 +185,18 @@ function checkUntrackedTodos(projectDir, config) {
   let untrackedCount = 0;
 
   for (const todo of todos) {
+    const todoTextLower = todo.text.toLowerCase().trim();
+    const searchText = todoTextLower.length > 20
+      ? todoTextLower.substring(0, 40)
+      : todoTextLower;
+
     // Check if the TODO is tracked in documentation
     // Improved matching: check full text AND file location context
     const isTracked = trackingContent.some(doc => {
       const content = doc.content;
-      const contentLower = content.toLowerCase();
-      const todoTextLower = todo.text.toLowerCase().trim();
+      const contentLower = doc.contentLower;
 
       // Match 1: Full TODO text appears in the doc (at least 20 chars or full text)
-      const searchText = todoTextLower.length > 20
-        ? todoTextLower.substring(0, 40)
-        : todoTextLower;
       const hasText = contentLower.includes(searchText);
 
       // Match 2: File location appears nearby in the doc
@@ -244,7 +245,8 @@ function loadTrackingDocs(projectDir, config) {
     const fullPath = resolve(projectDir, file);
     if (existsSync(fullPath)) {
       try {
-        docs.push({ file, content: readFileSync(fullPath, 'utf-8') });
+        const content = readFileSync(fullPath, 'utf-8');
+        docs.push({ file, content, contentLower: content.toLowerCase() });
       } catch { /* ignore */ }
     }
   }


### PR DESCRIPTION
**💡 What:** 
Precalculated `.toLowerCase()` on tracking documents when they are initially loaded in `loadTrackingDocs`. Moved the computation of `todoTextLower` and `searchText` outside the nested document-checking loop in `checkUntrackedTodos`.

**🎯 Why:**
Previously, for every TODO item (N), the validator iterated through every tracking document (M) and called `content.toLowerCase()` and `todo.text.toLowerCase().trim()`. This caused $O(N \times M)$ string operations, allocating huge amounts of temporary string data and significantly degrading performance on larger projects with many TODOs and large documentation files. 

**📊 Impact:** 
Eliminates redundant `.toLowerCase()` and substring allocations. Complexity in the string matching step drops from $N \times M$ lowercasing operations to just $N$ operations for TODOs and $M$ operations for tracking docs, substantially decreasing the runtime and garbage collection overhead.

**🔬 Measurement:** 
All 61 tests passed without any issue (`pnpm test`), taking under ~6s to run. Validated correctness by ensuring no test skips or logic changed. Expected to improve the overall execution duration of `docguard guard` and related subcommands when scanning multiple tracking docs.

---
*PR created automatically by Jules for task [2034382297432074595](https://jules.google.com/task/2034382297432074595) started by @raccioly*