### PR TITLE
🎨 Palette: [UX improvement] add accessibilityInformation to VS Code status bar item

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+## 2024-05-02 - VS Code Status Bar Screen Reader Accessibility
+**Learning:** VS Code `StatusBarItem` elements without explicit `accessibilityInformation` are often read poorly by screen readers, particularly when they rely heavily on visual icons (like `$(shield)`) or shorthand text (like `CDD: 85/100 (B)`). Screen readers might read literal icon identifiers or omit contextual meaning.
+**Action:** Always set `accessibilityInformation` (with descriptive `label` and appropriate `role`, e.g., 'button') when creating or dynamically updating a VS Code `StatusBarItem` to ensure robust screen reader support. This should be updated in sync with any visual text/tooltip changes.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -20,7 +20,7 @@ let fileWatcher;
 
 // ── Activation ─────────────────────────────────────────────────────────────
 
-function activate(context) {
+async function activate(context) {
   outputChannel = vscode.window.createOutputChannel('SpecGuard');
 
   // Status bar
@@ -29,6 +29,10 @@ function activate(context) {
   );
   statusBarItem.command = 'specguard.score';
   statusBarItem.tooltip = 'Click to see CDD score details';
+  statusBarItem.accessibilityInformation = {
+    label: 'CDD Score: Unknown',
+    role: 'button'
+  };
   context.subscriptions.push(statusBarItem);
 
   // Diagnostics
@@ -213,6 +217,10 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.accessibilityInformation = {
+        label: 'CDD Score: Unknown',
+        role: 'button'
+      };
       statusBarItem.show();
       return;
     }
@@ -232,6 +240,10 @@ async function refreshScore() {
 
     statusBarItem.text = `${icon} CDD: ${score}/100 (${grade})`;
     statusBarItem.tooltip = `CDD Score: ${score}/100 - ${tooltipStatus}\nClick to see details`;
+    statusBarItem.accessibilityInformation = {
+      label: `CDD Score: ${score} out of 100, Grade ${grade}, ${tooltipStatus}`,
+      role: 'button'
+    };
     statusBarItem.backgroundColor = score < threshold
       ? new vscode.ThemeColor('statusBarItem.warningBackground')
       : undefined;
@@ -243,6 +255,10 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.accessibilityInformation = {
+      label: 'CDD Score: Unknown due to error',
+      role: 'button'
+    };
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 What: Added `accessibilityInformation` to the VS Code `StatusBarItem` to ensure that screen readers can correctly interpret the status bar content. This updates dynamically whenever the text or tooltip is changed (e.g. during a score refresh or an error state).
🎯 Why: Status bar items relying on shorthand text (`CDD: 85/100`) and icons (`$(shield)`) lack context for screen reader users. Adding explicit labels transforms raw text into spoken phrases like "CDD Score: 85 out of 100, Grade B, Good", greatly improving accessibility for visually impaired developers.
📸 Before/After: Visual change is not present, changes are purely for screen-reader/assistive technologies.
♿ Accessibility: Ensures that `StatusBarItem` has a descriptive `label` and a clear `role` (`button`) to announce the current Canonical-Driven Development score comprehensively rather than parsing plain text strings.

---
*PR created automatically by Jules for task [7941747546161338341](https://jules.google.com/task/7941747546161338341) started by @raccioly*