### PR TITLE
🎨 Palette: Add accessibility info to status bar item

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2024-05-03 - Status Bar Accessibility Details
+**Learning:** Screen readers won't automatically read status bar items clearly if they rely heavily on icons or shorthand text like `$(verified) CDD: 95/100 (A)`. Without explicit `accessibilityInformation`, visually impaired developers miss important context about the extension's status and interactive capability.
+**Action:** When creating or dynamically updating VS Code extension UI elements like `StatusBarItem`, explicitly set `accessibilityInformation` (with `label` and `role`) to provide clear, up-to-date spoken context, especially when the item relies on icons or shorthand text.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -20,7 +20,7 @@ let fileWatcher;
 
 // ── Activation ─────────────────────────────────────────────────────────────
 
-function activate(context) {
+async function activate(context) {
   outputChannel = vscode.window.createOutputChannel('SpecGuard');
 
   // Status bar
@@ -29,6 +29,10 @@ function activate(context) {
   );
   statusBarItem.command = 'specguard.score';
   statusBarItem.tooltip = 'Click to see CDD score details';
+  statusBarItem.accessibilityInformation = {
+    label: 'SpecGuard CDD Score',
+    role: 'button'
+  };
   context.subscriptions.push(statusBarItem);
 
   // Diagnostics
@@ -213,6 +217,10 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.accessibilityInformation = {
+        label: 'SpecGuard CDD Score: Unknown',
+        role: 'button'
+      };
       statusBarItem.show();
       return;
     }
@@ -232,6 +240,10 @@ async function refreshScore() {
 
     statusBarItem.text = `${icon} CDD: ${score}/100 (${grade})`;
     statusBarItem.tooltip = `CDD Score: ${score}/100 - ${tooltipStatus}\nClick to see details`;
+    statusBarItem.accessibilityInformation = {
+      label: `SpecGuard CDD Score: ${score} out of 100, ${tooltipStatus}`,
+      role: 'button'
+    };
     statusBarItem.backgroundColor = score < threshold
       ? new vscode.ThemeColor('statusBarItem.warningBackground')
       : undefined;
@@ -243,6 +255,10 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.accessibilityInformation = {
+      label: 'SpecGuard CDD Score: Error',
+      role: 'button'
+    };
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 What: Added `accessibilityInformation` to the VS Code extension's status bar item to provide clear spoken text instead of reading raw markdown icons.
🎯 Why: Status bar items with icons and shorthand text (like `$(shield) CDD: ?`) are not read clearly by screen readers. Adding explicit accessibility labels solves this.
📸 Before/After: Not applicable (invisible a11y change).
♿ Accessibility: Provides proper ARIA-like context (`label` and `role`) to the status bar item so visually impaired developers can understand the current CDD score and state.

---
*PR created automatically by Jules for task [2260082455269697978](https://jules.google.com/task/2260082455269697978) started by @raccioly*