### PR TITLE
⚡ Bolt: [performance improvement] Precompute lowercase operations to prevent N*M complexity bottleneck

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - [Optimization]
 **Learning:** Found string.includes early return could speed up checkUntrackedTodos in cli/validators/todo-tracking.mjs.
 **Action:** Implement fast early return with includes check before doing expensive splitting or matching.
+## 2025-05-18 - [Optimization]
+**Learning:** Found an N*M complexity bottleneck where `.toLowerCase()` was repeatedly calculated in an inner loop comparing todos against tracking content docs in `cli/validators/todo-tracking.mjs`.
+**Action:** Precompute expensive string operations like `.toLowerCase()` outside inner loops during initial file loads or in outer loops.

--- a/cli/validators/todo-tracking.mjs
+++ b/cli/validators/todo-tracking.mjs
@@ -187,15 +187,17 @@ function checkUntrackedTodos(projectDir, config) {
   for (const todo of todos) {
     // Check if the TODO is tracked in documentation
     // Improved matching: check full text AND file location context
+    // Bolt Optimization: Precompute lowercase variants outside inner loop to prevent N*M complexity bottleneck
+    const todoTextLower = todo.text.toLowerCase().trim();
+    const searchText = todoTextLower.length > 20
+      ? todoTextLower.substring(0, 40)
+      : todoTextLower;
+
     const isTracked = trackingContent.some(doc => {
       const content = doc.content;
-      const contentLower = content.toLowerCase();
-      const todoTextLower = todo.text.toLowerCase().trim();
+      const contentLower = doc.contentLower;
 
       // Match 1: Full TODO text appears in the doc (at least 20 chars or full text)
-      const searchText = todoTextLower.length > 20
-        ? todoTextLower.substring(0, 40)
-        : todoTextLower;
       const hasText = contentLower.includes(searchText);
 
       // Match 2: File location appears nearby in the doc
@@ -244,7 +246,8 @@ function loadTrackingDocs(projectDir, config) {
     const fullPath = resolve(projectDir, file);
     if (existsSync(fullPath)) {
       try {
-        docs.push({ file, content: readFileSync(fullPath, 'utf-8') });
+        const content = readFileSync(fullPath, 'utf-8');
+        docs.push({ file, content, contentLower: content.toLowerCase() });
       } catch { /* ignore */ }
     }
   }


### PR DESCRIPTION
💡 What
Precomputed lowercase tracking content and hoisted `TODO` search string `.toLowerCase()` extractions outside the N*M `.some()` closure in `cli/validators/todo-tracking.mjs`.

🎯 Why
When comparing extracted `todos` to loaded tracking documentation, the `.toLowerCase()` and text subsetting operations were repeatedly recalculating exactly the same outputs inside an inner nested closure, introducing an unnecessary N*M processing bottleneck during validations.

📊 Impact
Prevents garbage collector overload and excessive CPU cycles by running string transformations O(M) and O(N) times respectively during file tracking validations rather than O(N*M) times.

🔬 Measurement
Tests were successfully executed using Node.js's native test runner (`pnpm test` equivalent) to confirm logic equivalency. Both `docguard guard` and general CLI commands remain unaffected while operating without the structural regression overhead.

---
*PR created automatically by Jules for task [13119780152435250170](https://jules.google.com/task/13119780152435250170) started by @raccioly*