### PR TITLE
🎨 Palette: [UX improvement] Add context-aware tooltips to VS Code extension error states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2024-05-04 - Map VS Code Status Bar Item Dynamic Properties to Tooltips
+**Learning:** When creating or updating VS Code extension status bar items, relying solely on static text during error states or missing states hides valuable contextual information from developers.
+**Action:** Always map dynamic properties like `icon`, `text`, and `backgroundColor` to corresponding informative `tooltip` properties so developers receive clear, context-aware feedback (e.g., specific error messages when CDD parsing fails).

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -20,7 +20,7 @@ let fileWatcher;
 
 // ── Activation ─────────────────────────────────────────────────────────────
 
-function activate(context) {
+async function activate(context) {
   outputChannel = vscode.window.createOutputChannel('SpecGuard');
 
   // Status bar
@@ -212,7 +212,9 @@ async function refreshScore() {
     const output = execSpecguard(dir, 'score --format json');
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
-      statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.text = '$(warning) CDD: ?';
+      statusBarItem.tooltip = 'Score unavailable - could not parse output. Click to see details.';
+      statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
       statusBarItem.show();
       return;
     }
@@ -242,7 +244,9 @@ async function refreshScore() {
 
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
-    statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.text = '$(error) CDD: Error';
+    statusBarItem.tooltip = `Error refreshing score: ${e.message}. Click to see details.`;
+    statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 What:
Added specific icons (`$(warning)` and `$(error)`), background theme colors (`warningBackground` and `errorBackground`), and dynamic tooltips to the VS Code status bar item when the CDD output fails to parse or when the underlying refresh command throws an exception.

🎯 Why:
Previously, the extension showed a generic `$(shield) CDD: ?` state when the CLI command completely failed or when the JSON output could not be parsed. This hidden failure state offered no clues to the user regarding the underlying problem. By making the status bar informative, developers immediately know what went wrong (e.g., an error parsing output or an exception thrown), preventing confusion and aiding in faster troubleshooting.

📸 Before/After:
Before: `$(shield) CDD: ?` with tooltip "Click to see CDD score details" regardless of whether the output was unparseable or errored out.
After:
- Unparseable: `$(warning) CDD: ?` with yellow background and tooltip "Score unavailable - could not parse output."
- Exception: `$(error) CDD: Error` with red background and tooltip "Error refreshing score: [e.message]."

♿ Accessibility:
Providing descriptive error messages via tooltips, along with distinct visual and icon changes, helps convey semantic meaning and context changes to screen readers and users navigating via keyboard, making the extension more accessible and transparent.

---
*PR created automatically by Jules for task [18254233441658972471](https://jules.google.com/task/18254233441658972471) started by @raccioly*