### PR TITLE
🎨 Palette: Improve status bar error context and state resets

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2024-05-06 - Status Bar Background Color Persistence
+**Learning:** In the VS Code extension API, if a status bar item is assigned a background color (e.g., `statusBarItem.warningBackground` or `statusBarItem.errorBackground`) during an error/warning state, that color persists across state changes unless explicitly reset. When transitioning back to a default or unknown state, the background color must be explicitly set to `undefined`.
+**Action:** Always set `statusBarItem.backgroundColor = undefined` when transitioning a status bar item to a normal or default state to avoid lingering warning/error colors from previous states.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -20,7 +20,7 @@ let fileWatcher;
 
 // ── Activation ─────────────────────────────────────────────────────────────
 
-function activate(context) {
+async function activate(context) {
   outputChannel = vscode.window.createOutputChannel('SpecGuard');
 
   // Status bar
@@ -213,6 +213,8 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.tooltip = 'CDD Score: Unknown. Click to see details.';
+      statusBarItem.backgroundColor = undefined;
       statusBarItem.show();
       return;
     }
@@ -242,7 +244,9 @@ async function refreshScore() {
 
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
-    statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.text = '$(error) CDD: Error';
+    statusBarItem.tooltip = `CDD Score Error: ${e.message}`;
+    statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
### 💡 What
Updated `vscode-extension/extension.js` to ensure the status bar explicitly resets its background color when transitioning to an unknown state (`backgroundColor = undefined`). Also, updated the error catch block to clearly show an error icon, error background, and the exact error message in the tooltip, instead of silently fading to an unknown state.

### 🎯 Why
When `execSpecguard` failed or returned non-JSON content, the extension either showed an unhelpful `CDD: ?` with lingering background colors from previous warnings, or completely hid the error message. This micro-UX improvement ensures developers have accurate, context-aware visual feedback and don't get confused by lingering red/yellow backgrounds on unknown states.

### 📸 Before/After
**Before:** If the score fell below threshold (yellow background), and then a CLI error occurred, the status bar showed `$(shield) CDD: ?` but *kept* the yellow background. Error states were swallowed entirely.
**After:** Error states show `$(error) CDD: Error` with a red background and the error in the tooltip. Unknown states explicitly clear the background color.

### ♿ Accessibility
Improves cognitive accessibility by providing consistent, clear context for state changes via explicit tooltips, rather than relying solely on icons or potentially stale background colors.

---
*PR created automatically by Jules for task [13486129242837321735](https://jules.google.com/task/13486129242837321735) started by @raccioly*