### PR TITLE
🎨 Palette: Fix lingering status bar states and tooltips

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2024-05-07 - Lingering Status Bar Background Colors
+**Learning:** In the VS Code extension API, status bar background colors (like `warningBackground`) persist across state changes unless explicitly cleared. When transitioning an item back to a default or unknown state, failing to reset this property results in misleading persistent visual warnings.
+**Action:** Always explicitly set `statusBarItem.backgroundColor = undefined` when transitioning back to a default, unknown, or error-fallback state to ensure accurate visual feedback.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -20,7 +20,7 @@ let fileWatcher;
 
 // ── Activation ─────────────────────────────────────────────────────────────
 
-function activate(context) {
+async function activate(context) {
   outputChannel = vscode.window.createOutputChannel('SpecGuard');
 
   // Status bar
@@ -213,6 +213,8 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.tooltip = 'CDD Score: Unknown\nClick to try refreshing';
+      statusBarItem.backgroundColor = undefined;
       statusBarItem.show();
       return;
     }
@@ -243,6 +245,8 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.tooltip = `CDD Score Error: ${e.message}\nClick to retry`;
+    statusBarItem.backgroundColor = undefined;
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
### 💡 What
This micro-UX improvement ensures that the DocGuard VS Code extension's status bar resets correctly and provides actionable tooltips when entering an unknown or errored state.

### 🎯 Why
In VS Code, status bar `backgroundColor` values (e.g., `warningBackground` and `errorBackground`) persist until manually cleared. Previously, if a user received a failing score (turning the background red/yellow) and then the extension ran into an unexpected error parsing the score, the status text would update to `$(shield) CDD: ?` but the background color would remain visually alarming, misleading the developer.

Additionally, static tooltips failed to inform the user *why* they were seeing an unknown state.

### 📸 Before/After
**Before:**
- CDD score parsing error happens after a failure.
- Status bar says: `$(shield) CDD: ?` with a bright warning background color.
- Tooltip says: `Click to see CDD score details`.

**After:**
- CDD score parsing error happens after a failure.
- Status bar says: `$(shield) CDD: ?` with a neutral (cleared) background color.
- Tooltip says: `CDD Score Error: [error msg]. Click to retry` or `CDD Score: Unknown. Click to try refreshing`.

### ♿ Accessibility
This change improves visual feedback clarity and ensures screen reader users (reading the tooltip text on focus) and visually impaired users navigating via keyboard get explicitly descriptive, state-relevant context rather than generic unhelpful text.

---
*PR created automatically by Jules for task [8007343808529796959](https://jules.google.com/task/8007343808529796959) started by @raccioly*