### PR TITLE
⚡ Bolt: [performance improvement] Optimize string conversions in checkUntrackedTodos

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - [Optimization]
 **Learning:** Found string.includes early return could speed up checkUntrackedTodos in cli/validators/todo-tracking.mjs.
 **Action:** Implement fast early return with includes check before doing expensive splitting or matching.
+
+## 2024-05-19 - [N^2 Bottleneck in nested loops]
+**Learning:** Recomputing `.toLowerCase()` in nested loops against multiple documents creates an N^2 performance bottleneck during TODO tracking validation.
+**Action:** Precompute expensive operations like `.toLowerCase()` during initial file load and store the result on the document object.

--- a/cli/validators/todo-tracking.mjs
+++ b/cli/validators/todo-tracking.mjs
@@ -185,17 +185,19 @@ function checkUntrackedTodos(projectDir, config) {
   let untrackedCount = 0;
 
   for (const todo of todos) {
+    // ⚡ Bolt: Precompute to avoid N^2 in nested loops
+    const todoTextLower = todo.text.toLowerCase().trim();
+    const searchText = todoTextLower.length > 20
+      ? todoTextLower.substring(0, 40)
+      : todoTextLower;
+
     // Check if the TODO is tracked in documentation
     // Improved matching: check full text AND file location context
     const isTracked = trackingContent.some(doc => {
       const content = doc.content;
-      const contentLower = content.toLowerCase();
-      const todoTextLower = todo.text.toLowerCase().trim();
+      const contentLower = doc.contentLower;
 
       // Match 1: Full TODO text appears in the doc (at least 20 chars or full text)
-      const searchText = todoTextLower.length > 20
-        ? todoTextLower.substring(0, 40)
-        : todoTextLower;
       const hasText = contentLower.includes(searchText);
 
       // Match 2: File location appears nearby in the doc
@@ -244,7 +246,8 @@ function loadTrackingDocs(projectDir, config) {
     const fullPath = resolve(projectDir, file);
     if (existsSync(fullPath)) {
       try {
-        docs.push({ file, content: readFileSync(fullPath, 'utf-8') });
+        const content = readFileSync(fullPath, 'utf-8');
+        docs.push({ file, content, contentLower: content.toLowerCase() });
       } catch { /* ignore */ }
     }
   }


### PR DESCRIPTION
💡 What: 
- Moved `content.toLowerCase()` into `loadTrackingDocs` to precompute the lowercased content once per file. 
- Hoisted `todo.text.toLowerCase().trim()` and string substring operations outside of the `trackingContent.some()` loop inside `checkUntrackedTodos`.

🎯 Why: 
Inside `checkUntrackedTodos`, `doc.content.toLowerCase()` was repeatedly executed in the nested inner loop against every file, for every TODO item. Furthermore, `todo.text.toLowerCase().trim()` was also redundantly recalculated for every document. For codebases with many TODOs and large tracking docs, this formed a noticeable O(N*M) string allocation and parsing bottleneck.

📊 Impact: 
Reduces redundant string lowercasing and trimming operations from `(Todos * Docs) + (Todos * Docs)` to `Todos + Docs`, significantly reducing memory allocation and improving the validator run time for large repositories.

🔬 Measurement: 
Run the CLI suite or manually execute `node cli/validators/todo-tracking.mjs` (indirectly via `guard`). The unit tests still pass via `pnpm test`.

---
*PR created automatically by Jules for task [17971078274132913942](https://jules.google.com/task/17971078274132913942) started by @raccioly*