### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix command injection in VS Code extension

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,9 @@
 **Vulnerability:** Found multiple instances where user-controlled inputs (`projectDir`, `filePath`) were interpolated directly into shell commands via `execSync` (e.g., `execSync(\`node "\${cliPath}" init --dir "\${projectDir}"\`)`).
 **Learning:** This is a classic command injection vulnerability. If `projectDir` contains shell metacharacters like `;`, `&&`, or `||`, it allows arbitrary command execution.
 **Prevention:** Always use `execFileSync` (or `execFile` for async) instead of `execSync` when executing commands with dynamic inputs. Pass arguments as an array to ensure they are passed directly to the executable without shell interpolation.
+## 2025-05-18 - [Command Injection via execSync in VS Code Extension]
+**Vulnerability:** The VS Code extension used `execSync` with the `workspaceDir` path concatenated into the command string, which is vulnerable to command injection if the workspace directory contains shell metacharacters.
+**Learning:** Treat workspace directory paths as untrusted user input that can contain shell metacharacters or spaces, requiring `execFileSync` with array arguments to prevent command injection and RCE vulnerabilities.
+**Prevention:** Always use `execFileSync` (or `execFile` for async) with array arguments instead of `execSync` when executing commands with dynamic inputs like workspace directories in extensions. Ensure `.cmd` wrappers are utilized for npm binaries on Windows.
+## 2025-05-18 - [String Parsing for Argument Arrays]
+**Learning:** When mitigating command injection by converting `execSync` with strings to `execFileSync` with argument arrays, naive `String.prototype.split(' ')` is insufficient and breaks paths with spaces. Use a regular expression or library that correctly respects quotes when parsing command strings into argument arrays.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -9,7 +9,7 @@
  */
 
 const vscode = require('vscode');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
@@ -20,7 +20,7 @@ let fileWatcher;
 
 // ── Activation ─────────────────────────────────────────────────────────────
 
-function activate(context) {
+async function activate(context) {
   outputChannel = vscode.window.createOutputChannel('SpecGuard');
 
   // Status bar
@@ -172,29 +172,68 @@ function getNodePath() {
 
 function findSpecguard(workspaceDir) {
   // Check local node_modules first
-  const localBin = path.join(workspaceDir, 'node_modules', '.bin', 'specguard');
+  const binName = process.platform === 'win32' ? 'specguard.cmd' : 'specguard';
+  const localBin = path.join(workspaceDir, 'node_modules', '.bin', binName);
   if (fs.existsSync(localBin)) return localBin;
 
   // Try npx
   return null;
 }
 
+// Helper to parse string arguments into an array respecting quotes
+function parseArgsStringToArgv(value) {
+  const args = [];
+  let currentArg = '';
+  let inDoubleQuote = false;
+  let inSingleQuote = false;
+
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+
+    if (char === '"' && !inSingleQuote) {
+      inDoubleQuote = !inDoubleQuote;
+    } else if (char === "'" && !inDoubleQuote) {
+      inSingleQuote = !inSingleQuote;
+    } else if (char === ' ' && !inDoubleQuote && !inSingleQuote) {
+      if (currentArg.length > 0) {
+        args.push(currentArg);
+        currentArg = '';
+      }
+    } else {
+      currentArg += char;
+    }
+  }
+
+  if (currentArg.length > 0) {
+    args.push(currentArg);
+  }
+
+  return args;
+}
+
 function execSpecguard(workspaceDir, args) {
   const localBin = findSpecguard(workspaceDir);
+  const argsArray = typeof args === 'string' ? parseArgsStringToArgv(args) : args;
 
-  let cmd;
+  let executable;
+  let finalArgs = [];
+
   if (localBin) {
-    cmd = `"${localBin}" ${args}`;
+    executable = localBin;
+    finalArgs = argsArray;
   } else {
-    cmd = `npx -y specguard ${args}`;
+    executable = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+    finalArgs = ['-y', 'specguard', ...argsArray];
   }
 
   try {
-    return execSync(cmd, {
+    return execFileSync(executable, finalArgs, {
       cwd: workspaceDir,
       encoding: 'utf-8',
       env: { ...process.env, NO_COLOR: '1' },
       timeout: 30000,
+      stdio: 'pipe',
+      shell: process.platform === 'win32'
     });
   } catch (e) {
     outputChannel.appendLine(`SpecGuard error: ${e.message}`);


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:** The VS Code extension used `execSync` to execute commands, passing the `workspaceDir` as a concatenated string. This creates a critical command injection vulnerability. If a user opened a workspace directory with a maliciously crafted name (e.g., containing shell metacharacters like `;`, `&&`, or `||`), those commands would be executed arbitrarily within the host environment.

🎯 **Impact:** Remote Code Execution (RCE) on the developer's machine if they are tricked into opening a workspace with a crafted directory name.

🔧 **Fix:**
1. Replaced `execSync` with `execFileSync` to avoid shell evaluation of paths.
2. Implemented `parseArgsStringToArgv` to safely tokenize string arguments into an array respecting both single and double quotes without breaking existing commands.
3. Passed arguments securely as an array to `execFileSync`.
4. Correctly handled Windows execution of `.cmd` files by dynamically determining the binary name and including the `shell` option strictly for Windows compatibility.
5. Marked the activation function correctly as async.

✅ **Verification:**
1. Verified syntax logic using `node -c vscode-extension/extension.js`.
2. Verified unit tests continue to pass (`pnpm test`).
3. Confirmed proper isolation of paths containing spaces via a scratchpad test.

---
*PR created automatically by Jules for task [13877094348091632134](https://jules.google.com/task/13877094348091632134) started by @raccioly*