### PR TITLE
🎨 Palette: [UX improvement] Context-aware status bar tooltips and state cleanup

### DIFF
--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -20,7 +20,7 @@ let fileWatcher;
 
 // ── Activation ─────────────────────────────────────────────────────────────
 
-function activate(context) {
+async function activate(context) {
   outputChannel = vscode.window.createOutputChannel('SpecGuard');
 
   // Status bar
@@ -213,6 +213,8 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.tooltip = 'CDD Score: Unknown\nCould not parse score output. Click to see details.';
+      statusBarItem.backgroundColor = undefined;
       statusBarItem.show();
       return;
     }
@@ -243,6 +245,8 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.tooltip = 'CDD Score: Error\nFailed to refresh score. Click to see details.';
+    statusBarItem.backgroundColor = undefined;
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
## 💡 What
- Added explicit, context-aware tooltips for the VS Code extension's status bar item when in an error or unknown state (e.g., "CDD Score: Unknown\nCould not parse score output. Click to see details.").
- Explicitly clears the `backgroundColor` on the status bar item (`statusBarItem.backgroundColor = undefined`) during these error states.
- Converted `function activate(context)` to `async function activate(context)` to resolve a `SyntaxError` caused by using `await` inside a synchronous function.

## 🎯 Why
When the extension encounters an error reading the CDD score, it gracefully falls back to displaying `$(shield) CDD: ?`. However, previously:
1. The static tooltip wouldn't explain why the state was unknown.
2. The background color of the status bar item would persist. If the user previously had a failing score (red background) and then triggered an error state, the status bar would show `?` but remain red, sending confusing, mixed signals.

## 📸 Before/After
**Before:** Status bar shows `CDD: ?` but might be styled red/yellow from previous runs, and hovering gives generic static text.
**After:** Status bar shows `CDD: ?` with the default background color, and hovering explains *why* the state could not be refreshed.

## ♿ Accessibility
Improves cognitive accessibility by ensuring developers aren't relying on stale visual cues (lingering red/yellow colors) when the actual state is "unknown." Descriptive tooltips provide clear, readable context for the error rather than requiring users to manually check output logs.

---
*PR created automatically by Jules for task [3474951075863041236](https://jules.google.com/task/3474951075863041236) started by @raccioly*