### PR TITLE
⚡ Bolt: [performance improvement] Precompute lowercase strings in todo-tracking

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - [Optimization]
 **Learning:** Found string.includes early return could speed up checkUntrackedTodos in cli/validators/todo-tracking.mjs.
 **Action:** Implement fast early return with includes check before doing expensive splitting or matching.
+## 2024-05-18 - [Optimization]
+**Learning:** Found N*M performance bottleneck in checkUntrackedTodos where document content was lowercased repeatedly within a nested loop.
+**Action:** Precompute expensive operations like `.toLowerCase()` during the initial file load and store it on the document object.

--- a/cli/validators/todo-tracking.mjs
+++ b/cli/validators/todo-tracking.mjs
@@ -189,7 +189,9 @@ function checkUntrackedTodos(projectDir, config) {
     // Improved matching: check full text AND file location context
     const isTracked = trackingContent.some(doc => {
       const content = doc.content;
-      const contentLower = content.toLowerCase();
+      // BOLT OPTIMIZATION: Avoid N*M lowercasing bottleneck by using precomputed contentLower
+      // previously: const contentLower = content.toLowerCase();
+      const contentLower = doc.contentLower;
       const todoTextLower = todo.text.toLowerCase().trim();
 
       // Match 1: Full TODO text appears in the doc (at least 20 chars or full text)
@@ -244,7 +246,10 @@ function loadTrackingDocs(projectDir, config) {
     const fullPath = resolve(projectDir, file);
     if (existsSync(fullPath)) {
       try {
-        docs.push({ file, content: readFileSync(fullPath, 'utf-8') });
+        const rawContent = readFileSync(fullPath, 'utf-8');
+        // BOLT OPTIMIZATION: Precompute lowercased content during file load to prevent N*M
+        // redundant lowercasing of large document strings in the inner checking loop.
+        docs.push({ file, content: rawContent, contentLower: rawContent.toLowerCase() });
       } catch { /* ignore */ }
     }
   }


### PR DESCRIPTION
💡 **What:** 
Optimized the `checkUntrackedTodos` validator inside `cli/validators/todo-tracking.mjs`. The content of tracking documents is now converted to lowercase once when the file is initially loaded, rather than being redundantly lowercased inside a `.some()` loop for every single `TODO` comment found in the project.

🎯 **Why:**
Previously, if the project contained `N` TODO items and `M` tracking documents, the entire contents of the tracking documents were lowercased `N * M` times. For large documentation files (like `ARCHITECTURE.md` or `ROADMAP.md`) and a codebase with hundreds of TODOs, this created a significant and unnecessary CPU bottleneck during string allocation.

📊 **Impact:**
Substantially reduces string allocations and garbage collection overhead during the `todo-tracking` validation phase. The time complexity for the text preparation phase drops from $O(N \times M)$ to $O(M)$.

🔬 **Measurement:**
Run `node --test tests/*.test.mjs` to verify functionality remains unchanged. You can benchmark the overall CLI speed improvements on large projects by running `time docguard guard` before and after this change.

---
*PR created automatically by Jules for task [2707253010487627082](https://jules.google.com/task/2707253010487627082) started by @raccioly*