### PR TITLE
⚡ Bolt: [performance improvement] Optimize todo tracking validation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - [Optimization]
 **Learning:** Found string.includes early return could speed up checkUntrackedTodos in cli/validators/todo-tracking.mjs.
 **Action:** Implement fast early return with includes check before doing expensive splitting or matching.
+
+## 2024-05-18 - [Avoid N^2 string operations in nested loops]
+**Learning:** Calling `.toLowerCase()` inside nested loops (like scanning N TODOs against M documents) introduces severe performance bottlenecks.
+**Action:** Precompute expensive operations like `.toLowerCase()` during the initial file load/mapping phase and store the result on the document object.

--- a/cli/validators/todo-tracking.mjs
+++ b/cli/validators/todo-tracking.mjs
@@ -185,17 +185,19 @@ function checkUntrackedTodos(projectDir, config) {
   let untrackedCount = 0;
 
   for (const todo of todos) {
+    // Precompute these string operations once per TODO, outside the inner loop
+    const todoTextLower = todo.text.toLowerCase().trim();
+    const searchText = todoTextLower.length > 20
+      ? todoTextLower.substring(0, 40)
+      : todoTextLower;
+
     // Check if the TODO is tracked in documentation
     // Improved matching: check full text AND file location context
     const isTracked = trackingContent.some(doc => {
       const content = doc.content;
-      const contentLower = content.toLowerCase();
-      const todoTextLower = todo.text.toLowerCase().trim();
+      const contentLower = doc.contentLower;
 
       // Match 1: Full TODO text appears in the doc (at least 20 chars or full text)
-      const searchText = todoTextLower.length > 20
-        ? todoTextLower.substring(0, 40)
-        : todoTextLower;
       const hasText = contentLower.includes(searchText);
 
       // Match 2: File location appears nearby in the doc
@@ -244,7 +246,8 @@ function loadTrackingDocs(projectDir, config) {
     const fullPath = resolve(projectDir, file);
     if (existsSync(fullPath)) {
       try {
-        docs.push({ file, content: readFileSync(fullPath, 'utf-8') });
+        const content = readFileSync(fullPath, 'utf-8');
+        docs.push({ file, content, contentLower: content.toLowerCase() });
       } catch { /* ignore */ }
     }
   }


### PR DESCRIPTION
💡 What:
Optimized the `validateTodoTracking` validator (`checkUntrackedTodos`) by precomputing expensive string conversions (`.toLowerCase()`). The `.toLowerCase()` operation for document content is now done once per document during file loading in `loadTrackingDocs`. The `.toLowerCase()` and `.trim()` operations for TODO items are now hoisted out of the `trackingContent.some` inner loop.

🎯 Why:
To prevent an O(N*M) performance bottleneck in nested loops. Previously, for N TODOs and M tracking documents, the code was executing `content.toLowerCase()` and `todo.text.toLowerCase().trim()` N*M times on every invocation of `docguard guard`. By precomputing these, we reduce string processing overhead significantly, making the CLI faster.

📊 Impact:
Significantly reduces string operations from O(N*M) to O(N + M) allocations during the untracked TODOs scan. This improves performance, particularly in codebases with many TODOs and large tracking documents.

🔬 Measurement:
Run `pnpm test` to verify that functionality remains exactly identical, with the only change being reduced execution time for `docguard guard`. Test suites run slightly faster due to the reduced string computation overhead.

---
*PR created automatically by Jules for task [13348412265487393214](https://jules.google.com/task/13348412265487393214) started by @raccioly*