### PR TITLE
🎨 Palette: Improve status bar state transitions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2024-05-09 - VS Code Status Bar Reset
+**Learning:** In the VS Code extension API, status bar background colors (like warningBackground) persist across state changes unless explicitly reset.
+**Action:** Always explicitly set `statusBarItem.backgroundColor = undefined` when transitioning back to a default or unknown state to avoid lingering warning/error colors.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -20,7 +20,7 @@ let fileWatcher;
 
 // ── Activation ─────────────────────────────────────────────────────────────
 
-function activate(context) {
+async function activate(context) {
   outputChannel = vscode.window.createOutputChannel('SpecGuard');
 
   // Status bar
@@ -213,6 +213,8 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.tooltip = 'CDD Score: Unknown\nClick to see details';
+      statusBarItem.backgroundColor = undefined;
       statusBarItem.show();
       return;
     }
@@ -243,6 +245,8 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.tooltip = 'CDD Score: Error\nClick to see details';
+    statusBarItem.backgroundColor = undefined;
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
### 💡 What
Updated the VS Code extension to explicitly reset the status bar background color to `undefined` when the CDD score check fails or enters an unknown state. Also added descriptive tooltips to explicitly indicate 'Unknown' or 'Error' states, and fixed a syntax error by converting the `activate` function to `async`.

### 🎯 Why
In the VS Code API, custom background colors (like `warningBackground`) persist across state updates unless explicitly reset. If an error occurs, a previous warning state's color could linger, providing confusing and inaccurate visual feedback to the developer. The added tooltips ensure developers have context for the status bar icon.

### 📸 Before/After
*   **Before:** If the CLI threw an error after previously scoring < 60, the status bar would display the fallback icon (`$(shield) CDD: ?`) but remain colored warning yellow/red, with no explanation in the tooltip.
*   **After:** The status bar clears the warning background and provides a tooltip reading "CDD Score: Error\nClick to see details" or "CDD Score: Unknown", making the current state immediately clear.

### ♿ Accessibility
Improves accessibility by ensuring visual color cues accurately match the system's underlying state, and by providing explicit text via tooltips for users who may rely on screen readers or hover interactions rather than color alone to deduce status.

---
*PR created automatically by Jules for task [4385439644776734721](https://jules.google.com/task/4385439644776734721) started by @raccioly*