### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in VS Code extension

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** Found multiple instances where user-controlled inputs (`projectDir`, `filePath`) were interpolated directly into shell commands via `execSync` (e.g., `execSync(\`node "\${cliPath}" init --dir "\${projectDir}"\`)`).
 **Learning:** This is a classic command injection vulnerability. If `projectDir` contains shell metacharacters like `;`, `&&`, or `||`, it allows arbitrary command execution.
 **Prevention:** Always use `execFileSync` (or `execFile` for async) instead of `execSync` when executing commands with dynamic inputs. Pass arguments as an array to ensure they are passed directly to the executable without shell interpolation.
+## 2025-05-18 - [Command Injection via execSync in VS Code Extension]
+**Vulnerability:** The VS Code extension used `execSync` with concatenated string arguments, including the potentially user-controlled `workspaceDir`, which could lead to command injection if the directory path contained shell metacharacters.
+**Learning:** Using `execSync` with untrusted directory paths in a VS Code extension is dangerous. We must use `execFileSync` with array arguments. Also, using `node <script>` instead of `.cmd` wrappers avoids Windows shell execution vulnerabilities.
+**Prevention:** Always use `execFileSync` with array arguments for executing external commands. Implement custom argument parsing to correctly tokenize string arguments, and execute Node.js scripts directly via `node` instead of relying on shell wrappers.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -9,7 +9,7 @@
  */
 
 const vscode = require('vscode');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
@@ -20,7 +20,7 @@ let fileWatcher;
 
 // ── Activation ─────────────────────────────────────────────────────────────
 
-function activate(context) {
+async function activate(context) {
   outputChannel = vscode.window.createOutputChannel('SpecGuard');
 
   // Status bar
@@ -170,32 +170,77 @@ function getNodePath() {
   return vscode.workspace.getConfiguration('specguard').get('nodePath') || 'node';
 }
 
+function parseArgs(str) {
+  const args = [];
+  let current = '';
+  let inQuote = false;
+  let quoteChar = '';
+  for (let i = 0; i < str.length; i++) {
+    const c = str[i];
+    if ((c === '"' || c === "'") && !inQuote) {
+      inQuote = true;
+      quoteChar = c;
+    } else if (c === quoteChar && inQuote) {
+      inQuote = false;
+    } else if (c === ' ' && !inQuote) {
+      if (current.length > 0) {
+        args.push(current);
+        current = '';
+      }
+    } else {
+      current += c;
+    }
+  }
+  if (current.length > 0) args.push(current);
+  return args;
+}
+
 function findSpecguard(workspaceDir) {
-  // Check local node_modules first
-  const localBin = path.join(workspaceDir, 'node_modules', '.bin', 'specguard');
-  if (fs.existsSync(localBin)) return localBin;
+  // Check local node_modules first, specifically the .mjs script
+  // to avoid .cmd wrapper on Windows which requires shell execution
+  const localScript = path.join(workspaceDir, 'node_modules', 'specguard', 'cli', 'docguard.mjs');
+  if (fs.existsSync(localScript)) return localScript;
 
   // Try npx
   return null;
 }
 
 function execSpecguard(workspaceDir, args) {
-  const localBin = findSpecguard(workspaceDir);
-
-  let cmd;
-  if (localBin) {
-    cmd = `"${localBin}" ${args}`;
-  } else {
-    cmd = `npx -y specguard ${args}`;
-  }
+  const localScript = findSpecguard(workspaceDir);
+  const parsedArgs = parseArgs(args);
+  const nodePath = getNodePath();
 
   try {
-    return execSync(cmd, {
-      cwd: workspaceDir,
-      encoding: 'utf-8',
-      env: { ...process.env, NO_COLOR: '1' },
-      timeout: 30000,
-    });
+    if (localScript) {
+      return execFileSync(nodePath, [localScript, ...parsedArgs], {
+        cwd: workspaceDir,
+        encoding: 'utf-8',
+        env: { ...process.env, NO_COLOR: '1' },
+        timeout: 30000,
+        stdio: 'pipe',
+      });
+    }
+
+    try {
+      return execFileSync('npx', ['-y', 'specguard', ...parsedArgs], {
+        cwd: workspaceDir,
+        encoding: 'utf-8',
+        env: { ...process.env, NO_COLOR: '1' },
+        timeout: 30000,
+        stdio: 'pipe',
+      });
+    } catch (e) {
+      if (e.code === 'ENOENT' && process.platform === 'win32') {
+        return execFileSync('npx.cmd', ['-y', 'specguard', ...parsedArgs], {
+          cwd: workspaceDir,
+          encoding: 'utf-8',
+          env: { ...process.env, NO_COLOR: '1' },
+          timeout: 30000,
+          stdio: 'pipe',
+        });
+      }
+      throw e;
+    }
   } catch (e) {
     outputChannel.appendLine(`SpecGuard error: ${e.message}`);
     return e.stdout || '';


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The VS Code extension used `execSync` with concatenated string arguments, which allowed command injection if the `workspaceDir` path contained shell metacharacters like `;`, `&&`, or `||`.
🎯 **Impact**: If a user opened a maliciously crafted folder name in VS Code, an attacker could achieve arbitrary Remote Code Execution (RCE) on the developer's machine with their permissions.
🔧 **Fix**: 
- Replaced `execSync` with `execFileSync`.
- Implemented a robust `parseArgs` function to correctly tokenize the command string arguments into an array.
- Directly executed the `.mjs` script via `node` where possible, avoiding Windows `.cmd` wrappers which fall back to shell execution.
- Added a fallback to `npx.cmd` explicitly on Windows if the node_modules script wasn't found.
✅ **Verification**: 
- Checked the extension using `node -c`.
- Ensured all 61 tests across 30 suites pass successfully (`node --test tests/*.test.mjs`).

---
*PR created automatically by Jules for task [9493210260264761375](https://jules.google.com/task/9493210260264761375) started by @raccioly*