### PR TITLE
🎨 Palette: [UX improvement] Clear status bar state on error

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2024-05-10 - VS Code Status Bar State Persistence
+**Learning:** In the VS Code extension API, status bar background colors and tooltips persist across state changes. Failing to explicitly clear them when returning to an unknown state causes lingering error colors and mismatched tooltips.
+**Action:** Always explicitly reset `statusBarItem.backgroundColor = undefined` and update the tooltip when transitioning a status bar item back to a default, unknown, or error state.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -213,6 +213,8 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.tooltip = 'CDD Score: Unknown';
+      statusBarItem.backgroundColor = undefined;
       statusBarItem.show();
       return;
     }
@@ -243,6 +245,8 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.tooltip = 'CDD Score: Error calculating score';
+    statusBarItem.backgroundColor = undefined;
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 What: The UX enhancement clears the `statusBarItem.backgroundColor` to `undefined` and updates `statusBarItem.tooltip` to provide contextual text when a JSON parse error or calculating exception occurs in the extension.

🎯 Why: The VS Code extension API persists the background color of status bar items across updates. If the score threshold drops below a passing limit, it sets a warning background color. If the next refresh hits an unknown error (e.g. unparseable JSON), the extension resets the text but the background color lingers, confusing users into thinking there is a warning state instead of an unknown error.

📸 Before/After: Visual change in the VS Code editor status bar (removes lingering warning/error colors when in error states, updates tooltip context).

♿ Accessibility: Ensures that status changes correctly reset their visual affordances so users depending on visual feedback (or screen reader tooltips) are not provided stale, inaccurate contexts.

---
*PR created automatically by Jules for task [579763078011676449](https://jules.google.com/task/579763078011676449) started by @raccioly*