### PR TITLE
🎨 Palette: [UX improvement] Fix lingering warning colors and tooltips in status bar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2024-05-15 - Lingering VS Code Status Bar Background Colors
+**Learning:** In the VS Code extension API, status bar background colors (like warningBackground) persist across state changes. If not explicitly reset to undefined when transitioning to an unknown or default state, they cause lingering error colors which confuse users and create accessibility issues (conflicting icon/color signals).
+**Action:** Always explicitly set statusBarItem.backgroundColor = undefined when a status bar item transitions away from a warning/error state to a default or unknown state.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -20,7 +20,7 @@ let fileWatcher;
 
 // ── Activation ─────────────────────────────────────────────────────────────
 
-function activate(context) {
+async function activate(context) {
   outputChannel = vscode.window.createOutputChannel('SpecGuard');
 
   // Status bar
@@ -213,6 +213,8 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.tooltip = 'CDD Score: Unavailable (Failed to parse score)';
+      statusBarItem.backgroundColor = undefined;
       statusBarItem.show();
       return;
     }
@@ -243,6 +245,8 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.tooltip = 'CDD Score: Error (Check output channel for details)';
+    statusBarItem.backgroundColor = undefined;
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
## 💡 What
Explicitly clear the `backgroundColor` on the VS Code extension status bar item during error states and provide context-aware tooltips instead of static text or leaving previous tooltips.

## 🎯 Why
When the CDD score check fails, the status bar reverted to a `?` icon but retained any previous warning background colors and tooltips. This created confusing UX and mixed signals for developers.

## 📸 Before/After
**Before:** Status bar shows `$(shield) CDD: ?` with a lingering yellow warning background and an outdated or static tooltip.
**After:** Status bar correctly resets to default background, with an informative tooltip explaining the unknown state (e.g., "CDD Score: Error (Check output channel for details)").

## ♿ Accessibility
Removes conflicting visual indicators (warning colors paired with unknown state icons) which could disproportionately confuse users relying heavily on color context or screen readers reading stale tooltip text.

---
*PR created automatically by Jules for task [18198393339998424184](https://jules.google.com/task/18198393339998424184) started by @raccioly*