### PR TITLE
🎨 Palette: [UX improvement] Clearer Status Bar Tooltip and Background Reset

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,7 +1,3 @@
-## 2024-04-16 - Web UI Components Constraint
-**Learning:** The docguard repository consists entirely of a Node.js CLI tool and a VS Code extension; it lacks web UI components (e.g., HTML, CSS, React, Vue), meaning traditional web-focused micro-UX enhancements do not apply.
-**Action:** Do not attempt traditional web-based UX enhancements here. Focus on CLI paradigms or skip UX enhancement requests if web-centric.
-
-## 2024-04-16 - Context-Aware Status Bar Tooltips
-**Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
-**Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+## 2024-05-12 - VS Code Status Bar Hover Experience
+**Learning:** In the VS Code extension API, static text tooltips for status bar items do not provide clear context, and error states can inadvertently persist if background colors aren't explicitly reset.
+**Action:** When updating status bar items, always bind dynamic properties like tooltips to the current state, and explicitly set `backgroundColor = undefined` when transitioning to an unknown state to prevent misleading error highlights.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -20,7 +20,7 @@ let fileWatcher;
 
 // ── Activation ─────────────────────────────────────────────────────────────
 
-function activate(context) {
+async function activate(context) {
   outputChannel = vscode.window.createOutputChannel('SpecGuard');
 
   // Status bar
@@ -213,6 +213,8 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.tooltip = 'CDD Score unavailable. Click to run score.';
+      statusBarItem.backgroundColor = undefined;
       statusBarItem.show();
       return;
     }
@@ -243,6 +245,8 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.tooltip = 'CDD Score unavailable. Click to run score.';
+    statusBarItem.backgroundColor = undefined;
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 What: Added a dynamic tooltip for the VS Code extension status bar when the score is unavailable, and explicitly reset `backgroundColor = undefined` in failure states. Also added the missing `async` keyword to the extension `activate` function.
🎯 Why: Previously, static text tooltips provided poor context, and if a project had a failing CDD score (red/yellow background), refreshing the score to an unavailable state (`?`) would cause the warning background color to persist, confusing developers.
📸 Before/After: Before: Hovering over the status bar in an unknown state showed a generic string, and backgrounds lingered. After: The tooltip explicitly states "CDD Score unavailable. Click to run score.", and the background correctly resets to the default theme color.
♿ Accessibility: Ensures that status indicators don't communicate conflicting signals (e.g., error color with a neutral text state), improving context clarity for users relying on visual status.

---
*PR created automatically by Jules for task [13356409410804761972](https://jules.google.com/task/13356409410804761972) started by @raccioly*