### PR TITLE
🧹 refactor testspec validation to separate concerns

### DIFF
--- a/cli/validators/test-spec.mjs
+++ b/cli/validators/test-spec.mjs
@@ -17,158 +17,14 @@ export function validateTestSpec(projectDir, config) {
   const content = readFileSync(testSpecPath, 'utf-8');
   const ptc = config.projectTypeConfig || {};
 
-  // Parse the Source-to-Test Map table (new header) or Service-to-Test Map (old header)
-  const serviceMapMatch = content.match(
-    /## (?:Service-to-Test Map|Source-to-Test Map)[\s\S]*?\n\|.*\|.*\|.*\|([\s\S]*?)(?=\n##|\n$|$)/
-  );
+  // 1. Parse Source-to-Test mapping
+  processSourceToTestMap(projectDir, content, results);
 
-  if (serviceMapMatch) {
-    const tableContent = serviceMapMatch[1];
-    const rows = tableContent
-      .split('\n')
-      .filter(line => line.startsWith('|') && !line.includes('---'));
+  // 2. Parse Critical User Journeys (E2E)
+  processCriticalJourneys(content, ptc, results);
 
-    for (const row of rows) {
-      const cells = row
-        .split('|')
-        .map(s => s.trim())
-        .filter(s => s.length > 0);
-
-      if (cells.length < 3) continue;
-
-      const sourceFile = cells[0];
-      const testFile = cells[1];
-      const status = cells[cells.length - 1]; // Last column is always status
-
-      // Skip template/example rows and italic placeholder rows
-      if (sourceFile.startsWith('<!--') || sourceFile === 'Source File' || sourceFile.startsWith('*')) continue;
-
-      if (status && status.includes('❌')) {
-        results.total++;
-        results.warnings.push(
-          `TEST-SPEC declares ${sourceFile} as ❌ — missing tests`
-        );
-      } else if (status && status.includes('⚠️')) {
-        results.total++;
-        results.warnings.push(
-          `TEST-SPEC declares ${sourceFile} as ⚠️ — partial coverage`
-        );
-      } else if (status && status.includes('✅')) {
-        results.total++;
-        results.passed++;
-      }
-
-      // ── File existence checks ───────────────────────────────────────
-      // Verify source file still exists (catch stale map entries)
-      const cleanSource = sourceFile.replace(/`/g, '').trim();
-      if (cleanSource && cleanSource !== '—' && cleanSource !== 'Source File') {
-        const sourcePath = resolve(projectDir, cleanSource);
-        if (!existsSync(sourcePath)) {
-          results.total++;
-          results.warnings.push(
-            `Source-to-Test Map: source file \`${cleanSource}\` not found on disk — stale entry?`
-          );
-        } else {
-          results.total++;
-          results.passed++;
-        }
-      }
-
-      // Verify test file exists (catch wrong/stale test references)
-      const cleanTest = testFile ? testFile.replace(/`/g, '').trim() : '';
-      if (cleanTest && cleanTest !== '—' && cleanTest !== 'Test File' &&
-          cleanTest !== 'Unit Test' && !cleanTest.includes('N/A')) {
-        const testPath = resolve(projectDir, cleanTest);
-        if (!existsSync(testPath)) {
-          results.total++;
-          results.warnings.push(
-            `Source-to-Test Map: test file \`${cleanTest}\` not found — referenced by ${cleanSource}`
-          );
-        } else {
-          results.total++;
-          results.passed++;
-        }
-      }
-    }
-  }
-
-  // Parse Critical User Journeys OR Critical CLI Flows
-  // Only check E2E journeys if the project type needs E2E
-  if (ptc.needsE2E !== false) {
-    const journeyMatch = content.match(
-      /## Critical (?:User Journeys|CLI Flows)[\s\S]*?\n\|.*\|.*\|.*\|.*\|([\s\S]*?)(?=\n##|\n---|\n$|$)/
-    );
-
-    if (journeyMatch) {
-      const tableContent = journeyMatch[1];
-      const rows = tableContent
-        .split('\n')
-        .filter(line => line.startsWith('|') && !line.includes('---'));
-
-      for (const row of rows) {
-        const cells = row
-          .split('|')
-          .map(s => s.trim())
-          .filter(s => s.length > 0);
-
-        if (cells.length < 4) continue;
-
-        const [num, journey, testFile, status] = cells;
-        // Skip template rows (comments), headers
-        if (num.startsWith('<!--') || num === '#' || journey.startsWith('<!--')) continue;
-
-        if (status && status.includes('❌')) {
-          results.total++;
-          results.warnings.push(
-            `E2E Journey #${num} (${journey}) — missing test: ${testFile}`
-          );
-        } else if (status && status.includes('✅')) {
-          results.total++;
-          results.passed++;
-        }
-      }
-    }
-  }
-
-  // If no test spec entries parsed, check if tests exist anywhere
-  if (results.total === 0) {
-    results.total = 1;
-
-    // 1. Check top-level test dirs
-    const commonTestDirs = ['tests', 'test', '__tests__', 'spec'];
-    const hasTestDir = commonTestDirs.some(d =>
-      existsSync(resolve(projectDir, d))
-    );
-
-    // 2. Check co-located tests (src/**/__tests__/, src/**/*.test.*)
-    let hasColocated = false;
-    if (!hasTestDir) {
-      const sourceRoots = ['src', 'app', 'lib', 'packages'];
-      for (const root of sourceRoots) {
-        const rootPath = resolve(projectDir, root);
-        if (existsSync(rootPath) && hasTestFilesRecursive(rootPath)) {
-          hasColocated = true;
-          break;
-        }
-      }
-    }
-
-    // 3. Check vitest/jest config for custom patterns
-    let hasConfigTests = false;
-    if (!hasTestDir && !hasColocated) {
-      const configs = ['vitest.config.ts', 'vitest.config.js', 'jest.config.ts', 'jest.config.js'];
-      hasConfigTests = configs.some(f => existsSync(resolve(projectDir, f)));
-    }
-
-    if (hasTestDir || hasColocated || hasConfigTests) {
-      results.passed = 1;
-    } else {
-      results.warnings.push(
-        'No test directory or co-located test files found. ' +
-        'Expected: tests/, src/**/__tests__/, or src/**/*.test.* files'
-      );
-    }
-  }
+  // 3. Fallback check if no entries were found in TEST-SPEC.md
+  runTestExistenceFallback(projectDir, results);
 
   return results;
 }
@@ -192,4 +48,147 @@ function hasTestFilesRecursive(dir) {
     } catch { continue; }
   }
   return false;
+}
+
+/** Parse and verify the Source-to-Test Map table */
+function processSourceToTestMap(projectDir, content, results) {
+  const serviceMapMatch = content.match(
+    /## (?:Service-to-Test Map|Source-to-Test Map)[\s\S]*?\n\|.*\|.*\|.*\|([\s\S]*?)(?=\n##|\n$|$)/
+  );
+
+  if (!serviceMapMatch) return;
+
+  const tableContent = serviceMapMatch[1];
+  const rows = tableContent
+    .split('\n')
+    .filter(line => line.startsWith('|') && !line.includes('---'));
+
+  for (const row of rows) {
+    const cells = row
+      .split('|')
+      .map(s => s.trim())
+      .filter(s => s.length > 0);
+
+    if (cells.length < 3) continue;
+
+    const sourceFile = cells[0];
+    const testFile = cells[1];
+    const status = cells[cells.length - 1];
+
+    if (sourceFile.startsWith('<!--') || sourceFile === 'Source File' || sourceFile.startsWith('*')) continue;
+
+    if (status && status.includes('❌')) {
+      results.total++;
+      results.warnings.push(`TEST-SPEC declares ${sourceFile} as ❌ — missing tests`);
+    } else if (status && status.includes('⚠️')) {
+      results.total++;
+      results.warnings.push(`TEST-SPEC declares ${sourceFile} as ⚠️ — partial coverage`);
+    } else if (status && status.includes('✅')) {
+      results.total++;
+      results.passed++;
+    }
+
+    const cleanSource = sourceFile.replace(/`/g, '').trim();
+    if (cleanSource && cleanSource !== '—' && cleanSource !== 'Source File') {
+      const sourcePath = resolve(projectDir, cleanSource);
+      if (!existsSync(sourcePath)) {
+        results.total++;
+        results.warnings.push(`Source-to-Test Map: source file \`${cleanSource}\` not found on disk — stale entry?`);
+      } else {
+        results.total++;
+        results.passed++;
+      }
+    }
+
+    const cleanTest = testFile ? testFile.replace(/`/g, '').trim() : '';
+    if (cleanTest && cleanTest !== '—' && cleanTest !== 'Test File' &&
+        cleanTest !== 'Unit Test' && !cleanTest.includes('N/A')) {
+      const testPath = resolve(projectDir, cleanTest);
+      if (!existsSync(testPath)) {
+        results.total++;
+        results.warnings.push(`Source-to-Test Map: test file \`${cleanTest}\` not found — referenced by ${cleanSource}`);
+      } else {
+        results.total++;
+        results.passed++;
+      }
+    }
+  }
+}
+
+/** Fallback check for any test presence if no TEST-SPEC entries found */
+function runTestExistenceFallback(projectDir, results) {
+  if (results.total > 0) return;
+
+  results.total = 1;
+
+  // 1. Check top-level test dirs
+  const commonTestDirs = ['tests', 'test', '__tests__', 'spec'];
+  const hasTestDir = commonTestDirs.some(d =>
+    existsSync(resolve(projectDir, d))
+  );
+
+  // 2. Check co-located tests
+  let hasColocated = false;
+  if (!hasTestDir) {
+    const sourceRoots = ['src', 'app', 'lib', 'packages'];
+    for (const root of sourceRoots) {
+      const rootPath = resolve(projectDir, root);
+      if (existsSync(rootPath) && hasTestFilesRecursive(rootPath)) {
+        hasColocated = true;
+        break;
+      }
+    }
+  }
+
+  // 3. Check configuration files
+  let hasConfigTests = false;
+  if (!hasTestDir && !hasColocated) {
+    const configs = ['vitest.config.ts', 'vitest.config.js', 'jest.config.ts', 'jest.config.js'];
+    hasConfigTests = configs.some(f => existsSync(resolve(projectDir, f)));
+  }
+
+  if (hasTestDir || hasColocated || hasConfigTests) {
+    results.passed = 1;
+  } else {
+    results.warnings.push(
+      'No test directory or co-located test files found. ' +
+      'Expected: tests/, src/**/__tests__/, or src/**/*.test.* files'
+    );
+  }
+}
+
+/** Parse and verify Critical User Journeys or Critical CLI Flows */
+function processCriticalJourneys(content, ptc, results) {
+  if (ptc.needsE2E === false) return;
+
+  const journeyMatch = content.match(
+    /## Critical (?:User Journeys|CLI Flows)[\s\S]*?\n\|.*\|.*\|.*\|.*\|([\s\S]*?)(?=\n##|\n---|\n$|$)/
+  );
+
+  if (!journeyMatch) return;
+
+  const tableContent = journeyMatch[1];
+  const rows = tableContent
+    .split('\n')
+    .filter(line => line.startsWith('|') && !line.includes('---'));
+
+  for (const row of rows) {
+    const cells = row
+      .split('|')
+      .map(s => s.trim())
+      .filter(s => s.length > 0);
+
+    if (cells.length < 4) continue;
+
+    const [num, journey, testFile, status] = cells;
+    if (num.startsWith('<!--') || num === '#' || journey.startsWith('<!--')) continue;
+
+    if (status && status.includes('❌')) {
+      results.total++;
+      results.warnings.push(`E2E Journey #${num} (${journey}) — missing test: ${testFile}`);
+    } else if (status && status.includes('✅')) {
+      results.total++;
+      results.passed++;
+    }
+  }
 }

--- a/tests/test-spec-validator.test.mjs
+++ b/tests/test-spec-validator.test.mjs
@@ -1,0 +1,115 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { validateTestSpec } from '../cli/validators/test-spec.mjs';
+
+describe('validateTestSpec', () => {
+  it('returns empty results if TEST-SPEC.md does not exist', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'docguard-test-spec-'));
+    try {
+      const config = { projectTypeConfig: {} };
+      const results = validateTestSpec(tmpDir, config);
+      assert.equal(results.name, 'test-spec');
+      assert.equal(results.total, 0);
+      assert.equal(results.passed, 0);
+      assert.equal(results.warnings.length, 0);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('parses Source-to-Test Map correctly', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'docguard-test-spec-'));
+    try {
+      mkdirSync(join(tmpDir, 'docs-canonical'), { recursive: true });
+      mkdirSync(join(tmpDir, 'src'), { recursive: true });
+      mkdirSync(join(tmpDir, 'tests'), { recursive: true });
+
+      writeFileSync(join(tmpDir, 'src', 'app.js'), 'console.log("hello")');
+      writeFileSync(join(tmpDir, 'tests', 'app.test.js'), 'test()');
+
+      const content = `
+## Source-to-Test Map
+| Source File | Test File | Description | Status |
+|---|---|---|---|
+| src/app.js | tests/app.test.js | Main app | ✅ |
+| src/missing.js | tests/missing.test.js | Missing | ❌ |
+`;
+      writeFileSync(join(tmpDir, 'docs-canonical', 'TEST-SPEC.md'), content);
+
+      const config = { projectTypeConfig: {} };
+      const results = validateTestSpec(tmpDir, config);
+
+      // rows:
+      // 1. status ✅ (total++, passed++)
+      // 2. status ❌ (total++, warning++)
+      // 3. source src/app.js exists (total++, passed++)
+      // 4. test tests/app.test.js exists (total++, passed++)
+      // 5. source src/missing.js missing (total++, warning++)
+      // 6. test tests/missing.test.js missing (total++, warning++)
+
+      assert.equal(results.total, 6);
+      assert.equal(results.passed, 3);
+      assert.equal(results.warnings.length, 3);
+      assert.ok(results.warnings.some(w => w.includes('src/missing.js as ❌')));
+      assert.ok(results.warnings.some(w => w.includes('source file `src/missing.js` not found')));
+      assert.ok(results.warnings.some(w => w.includes('test file `tests/missing.test.js` not found')));
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('parses Critical CLI Flows correctly', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'docguard-test-spec-'));
+    try {
+      mkdirSync(join(tmpDir, 'docs-canonical'), { recursive: true });
+      const content = `
+## Critical CLI Flows
+| # | Journey | Test File | Status |
+|---|---|---|---|
+| 1 | Basic Flow | tests/e2e.test.js | ✅ |
+| 2 | Advanced Flow | tests/adv.test.js | ❌ |
+`;
+      writeFileSync(join(tmpDir, 'docs-canonical', 'TEST-SPEC.md'), content);
+
+      const config = { projectTypeConfig: { needsE2E: true } };
+      const results = validateTestSpec(tmpDir, config);
+
+      // Source-to-Test Map not found, so only Critical CLI Flows checked
+      // 1. status ✅ (total++, passed++)
+      // 2. status ❌ (total++, warning++)
+
+      assert.equal(results.total, 2);
+      assert.equal(results.passed, 1);
+      assert.equal(results.warnings.length, 1);
+      assert.match(results.warnings[0], /E2E Journey #2/);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips E2E if needsE2E is false', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'docguard-test-spec-'));
+    try {
+      mkdirSync(join(tmpDir, 'docs-canonical'), { recursive: true });
+      const content = `
+## Critical CLI Flows
+| # | Journey | Test File | Status |
+|---|---|---|---|
+| 1 | Basic Flow | tests/e2e.test.js | ❌ |
+`;
+      writeFileSync(join(tmpDir, 'docs-canonical', 'TEST-SPEC.md'), content);
+
+      const config = { projectTypeConfig: { needsE2E: false } };
+      const results = validateTestSpec(tmpDir, config);
+
+      // E2E skipped, total should be 1 (fallback check) if nothing else found
+      assert.equal(results.total, 1);
+      assert.equal(results.passed, 0);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
🎯 **What:** Extracted complex logic from `validateTestSpec` into modular helper functions: `processSourceToTestMap`, `processCriticalJourneys`, and `runTestExistenceFallback`.
💡 **Why:** Improves maintainability and readability by reducing the size and cyclomatic complexity of the main validation function. Separates parsing of different markdown sections and fallback logic.
✅ **Verification:** Created a new unit test suite `tests/test-spec-validator.test.mjs` covering various scenarios (missing docs, source-to-test map parsing, E2E journey parsing, fallback checks). Ran full project test suite with `pnpm test`. All tests passed.
✨ **Result:** A cleaner, more modular validator that is easier to extend and test.

---
*PR created automatically by Jules for task [7786533403437988074](https://jules.google.com/task/7786533403437988074) started by @raccioly*