### PR TITLE
🎨 Palette: Add context-aware accessibility to Status Bar Item

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2024-04-28 - Context-Aware Status Bar Tooltips
+**Learning:** Dynamically updated VS Code \`StatusBarItem\`s require explicitly maintained \`accessibilityInformation\` (with \`label\` and \`role\`) to ensure screen readers provide accurate spoken context matching the visual state.
+**Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to a corresponding \`accessibilityInformation\` object that explains what the visual change means.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -20,7 +20,7 @@ let fileWatcher;
 
 // ── Activation ─────────────────────────────────────────────────────────────
 
-function activate(context) {
+async function activate(context) {
   outputChannel = vscode.window.createOutputChannel('SpecGuard');
 
   // Status bar
@@ -29,6 +29,10 @@ function activate(context) {
   );
   statusBarItem.command = 'specguard.score';
   statusBarItem.tooltip = 'Click to see CDD score details';
+  statusBarItem.accessibilityInformation = {
+    role: 'button',
+    label: 'CDD Score Details'
+  };
   context.subscriptions.push(statusBarItem);
 
   // Diagnostics
@@ -213,6 +217,7 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.accessibilityInformation = { role: 'button', label: 'CDD Score: Unknown' };
       statusBarItem.show();
       return;
     }
@@ -232,6 +237,10 @@ async function refreshScore() {
 
     statusBarItem.text = `${icon} CDD: ${score}/100 (${grade})`;
     statusBarItem.tooltip = `CDD Score: ${score}/100 - ${tooltipStatus}\nClick to see details`;
+    statusBarItem.accessibilityInformation = {
+      role: 'button',
+      label: `CDD Score: ${score} out of 100, ${tooltipStatus}`
+    };
     statusBarItem.backgroundColor = score < threshold
       ? new vscode.ThemeColor('statusBarItem.warningBackground')
       : undefined;
@@ -243,6 +252,7 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.accessibilityInformation = { role: 'button', label: 'CDD Score: Unknown' };
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
**💡 What**
Added dynamic `accessibilityInformation` properties (`label` and `role`) to the VS Code `StatusBarItem` to provide descriptive text to screen readers. Also fixed a missing `async` keyword on the `activate` function.

**🎯 Why**
Previously, the extension status bar provided visual feedback (icons, text, background colors) but had static tooltips and no explicit accessibility labels, leaving screen reader users without context when the CDD score changed dynamically. Providing context-aware accessibility labels greatly improves usability.

**📸 Before/After**
*Before:* Screen readers announced generic button text or nothing when the score updated.
*After:* Screen readers explicitly announce updates like `"CDD Score: 85 out of 100, Good"` when the status bar refreshes.

**♿ Accessibility**
- Added explicit `role: 'button'` to the status bar item.
- Added dynamic `label` updates that combine the score and the human-readable tooltip status.
- Addressed fallback/error states with clear `"CDD Score: Unknown"` labels.

---
*PR created automatically by Jules for task [9343724513546140251](https://jules.google.com/task/9343724513546140251) started by @raccioly*