### PR TITLE
Fix: Update section header comment to avoid triggering TODO scanners

### DIFF
--- a/cli/validators/todo-tracking.mjs
+++ b/cli/validators/todo-tracking.mjs
@@ -67,7 +67,7 @@ export function validateTodoTracking(projectDir, config) {
   results.passed += skipResults.passed;
   results.total += skipResults.total;
 
-  // ── Part 2: Untracked TODOs/FIXMEs ──
+  // ── Part 2: Untracked Annotations ──
   const todoResults = checkUntrackedTodos(projectDir, config);
   results.errors.push(...todoResults.errors);
   results.warnings.push(...todoResults.warnings);
@@ -155,7 +155,7 @@ function checkSkippedTests(projectDir, config) {
   return { errors, warnings, passed, total };
 }
 
-// ──── Untracked TODOs ──────────────────────────────────────────────────────
+// ──── Untracked Annotations ────────────────────────────────────────────────
 
 /**
  * Scan source files for TODO/FIXME annotations and check if they appear


### PR DESCRIPTION
Updates section headers in `cli/validators/todo-tracking.mjs` to say "Annotations" instead of "TODOs/FIXMEs" or "TODOs". This avoids triggering codebase scanners that might incorrectly pick up these header comments as untracked TODOs.

---
*PR created automatically by Jules for task [521479262709372241](https://jules.google.com/task/521479262709372241) started by @raccioly*