### PR TITLE
🧪 Add missing test coverage for validateDrift

### DIFF
--- a/DRIFT-LOG.md
+++ b/DRIFT-LOG.md
@@ -9,3 +9,4 @@
 | 2026-03-13 | `cli/commands/generate.mjs` | ARCHITECTURE.md | DRIFT-LOG.md template includes `// DRIFT: reason` as placeholder text. | Info | By design — template content |
 | 2026-03-13 | `cli/commands/agents.mjs` | ARCHITECTURE.md | Agent config generators include `// DRIFT: reason` as instruction text for AI agents. 3 occurrences across Windsurf, Cursor, and generic agent configs. | Info | By design — instruction content |
 | 2026-03-13 | `cli/validators/drift.mjs` | ARCHITECTURE.md | Drift validator references `// DRIFT:` pattern in JSDoc and regex. | Info | By design — validator implementation |
+| 2026-05-12 | `tests/drift.test.mjs` | ARCHITECTURE.md | Drift validator tests use `// DRIFT:` comments to simulate project files having drift comments. | Info | By design — test implementation |

--- a/tests/drift.test.mjs
+++ b/tests/drift.test.mjs
@@ -1,0 +1,81 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { validateDrift } from '../cli/validators/drift.mjs';
+
+describe('validateDrift', () => {
+  it('returns passed when no DRIFT comments are found', () => {
+    const tempDir = fs.mkdtempSync(join(tmpdir(), 'docguard-test-drift-'));
+    try {
+      const config = { requiredFiles: { driftLog: 'DRIFT-LOG.md' } };
+      fs.writeFileSync(join(tempDir, 'test.js'), 'console.log("hello");');
+
+      const result = validateDrift(tempDir, config);
+      assert.equal(result.name, 'drift');
+      assert.equal(result.passed, 1);
+      assert.equal(result.total, 1);
+      assert.deepEqual(result.errors, []);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns errors when DRIFT comments exist but DRIFT-LOG.md is missing', () => {
+    const tempDir = fs.mkdtempSync(join(tmpdir(), 'docguard-test-drift-'));
+    try {
+      const config = { requiredFiles: { driftLog: 'DRIFT-LOG.md' } };
+      fs.writeFileSync(join(tempDir, 'test.js'), '// DRIFT: We needed to do this\nconsole.log("hello");');
+
+      const result = validateDrift(tempDir, config);
+      assert.equal(result.name, 'drift');
+      assert.equal(result.total, 1);
+      assert.equal(result.passed, 0);
+      assert.equal(result.errors.length, 1);
+      assert.ok(result.errors[0].includes("has DRIFT comment but DRIFT-LOG.md doesn't exist"));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns errors when DRIFT comments exist but are not mentioned in DRIFT-LOG.md', () => {
+    const tempDir = fs.mkdtempSync(join(tmpdir(), 'docguard-test-drift-'));
+    try {
+      const config = { requiredFiles: { driftLog: 'DRIFT-LOG.md' } };
+      fs.writeFileSync(join(tempDir, 'test.js'), '// DRIFT: We needed to do this\nconsole.log("hello");');
+      fs.writeFileSync(join(tempDir, 'DRIFT-LOG.md'), '# Drift Log\nNothing here.');
+
+      const result = validateDrift(tempDir, config);
+      assert.equal(result.name, 'drift');
+      assert.equal(result.total, 1);
+      assert.equal(result.passed, 0);
+      assert.equal(result.errors.length, 1);
+      assert.ok(result.errors[0].includes("DRIFT comment not logged in DRIFT-LOG.md"));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns passed when DRIFT comments are correctly logged in DRIFT-LOG.md for various styles', () => {
+    const tempDir = fs.mkdtempSync(join(tmpdir(), 'docguard-test-drift-'));
+    try {
+      const config = { requiredFiles: { driftLog: 'DRIFT-LOG.md' } };
+
+      fs.writeFileSync(join(tempDir, 'test1.js'), '// DRIFT: JS comment\n');
+      fs.writeFileSync(join(tempDir, 'test2.py'), '# DRIFT: Python comment\n');
+      fs.writeFileSync(join(tempDir, 'test3.c'), '/* DRIFT: C comment */\n');
+      fs.writeFileSync(join(tempDir, 'test4.java'), '-- DRIFT: SQL comment in java file for testing regex\n');
+
+      fs.writeFileSync(join(tempDir, 'DRIFT-LOG.md'), '# Drift Log\n- test1.js\n- test2.py\n- test3.c\n- test4.java\n');
+
+      const result = validateDrift(tempDir, config);
+      assert.equal(result.name, 'drift');
+      assert.equal(result.total, 4);
+      assert.equal(result.passed, 4);
+      assert.equal(result.errors.length, 0);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
🎯 **What:** The `validateDrift` function in `cli/validators/drift.mjs` was missing unit tests. This PR adds a comprehensive test suite to cover its functionality.

📊 **Coverage:** The new tests cover the following scenarios:
- Happy path: Code without any `DRIFT:` comments correctly passes.
- Error state: A `DRIFT:` comment exists, but the required `DRIFT-LOG.md` file is missing entirely.
- Error state: A `DRIFT:` comment exists, but the specific file is not documented within the existing `DRIFT-LOG.md`.
- Happy path (multi-language): `DRIFT:` comments are correctly identified and validated across various supported code extensions (e.g., `.js`, `.py`, `.c`, `.java`) and comment styles (`//`, `#`, `/*`, `--`).

✨ **Result:** Test coverage for `cli/validators/drift.mjs` is now established, ensuring the function correctly enforces the drift tracking policy and protecting against future regressions.

---
*PR created automatically by Jules for task [7755852056576392061](https://jules.google.com/task/7755852056576392061) started by @raccioly*