### PR TITLE
🧪 [testing improvement] Add comprehensive test suite for hooks command

### DIFF
--- a/tests/hooks.test.mjs
+++ b/tests/hooks.test.mjs
@@ -1,0 +1,117 @@
+import { describe, it, afterEach, beforeEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, mkdirSync, rmSync, existsSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { runHooks } from '../cli/commands/hooks.mjs';
+
+describe('runHooks function', () => {
+    let tmpDir;
+    let oldLog;
+    let oldExit;
+    let logs;
+
+    beforeEach(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), 'sg-hooks-'));
+        oldLog = console.log;
+        oldExit = process.exit;
+        logs = [];
+        console.log = (...args) => { logs.push(args.join(' ')); };
+    });
+
+    afterEach(() => {
+        console.log = oldLog;
+        process.exit = oldExit;
+        if (tmpDir && existsSync(tmpDir)) {
+            rmSync(tmpDir, { recursive: true, force: true });
+        }
+    });
+
+    it('installs hooks', () => {
+        mkdirSync(join(tmpDir, '.git'));
+        runHooks(tmpDir, { projectName: 'Test' }, {});
+        assert.ok(existsSync(join(tmpDir, '.git', 'hooks', 'pre-commit')));
+        assert.ok(existsSync(join(tmpDir, '.git', 'hooks', 'pre-push')));
+        assert.ok(existsSync(join(tmpDir, '.git', 'hooks', 'commit-msg')));
+    });
+
+    it('fails if not a git repository', () => {
+        let exitCode = null;
+        process.exit = (code) => { exitCode = code; throw new Error("process.exit"); };
+
+        try {
+            runHooks(tmpDir, { projectName: 'Test' }, {});
+        } catch (e) {
+            if (e.message !== "process.exit") throw e;
+        }
+
+        assert.strictEqual(exitCode, 1);
+        assert.ok(logs.some(log => log.includes('Not a git repository')));
+    });
+
+    it('fails with unknown hook type', () => {
+        mkdirSync(join(tmpDir, '.git'));
+        let exitCode = null;
+        process.exit = (code) => { exitCode = code; throw new Error("process.exit"); };
+
+        try {
+            runHooks(tmpDir, { projectName: 'Test' }, { type: 'unknown' });
+        } catch (e) {
+            if (e.message !== "process.exit") throw e;
+        }
+
+        assert.strictEqual(exitCode, 1);
+        assert.ok(logs.some(log => log.includes('Unknown hook type')));
+    });
+
+    it('lists available hooks', () => {
+        mkdirSync(join(tmpDir, '.git'));
+        runHooks(tmpDir, { projectName: 'Test' }, { list: true });
+        assert.ok(logs.some(log => log.includes('Available hooks')));
+        assert.ok(logs.some(log => log.includes('pre-commit')));
+    });
+
+    it('removes hooks', () => {
+        mkdirSync(join(tmpDir, '.git'));
+        mkdirSync(join(tmpDir, '.git', 'hooks'));
+        writeFileSync(join(tmpDir, '.git', 'hooks', 'pre-commit'), 'DocGuard hook');
+        runHooks(tmpDir, { projectName: 'Test' }, { remove: true });
+        assert.ok(!existsSync(join(tmpDir, '.git', 'hooks', 'pre-commit')));
+        assert.ok(logs.some(log => log.includes('Removed: pre-commit')));
+    });
+
+    it('skips non-DocGuard hooks when removing', () => {
+        mkdirSync(join(tmpDir, '.git'));
+        mkdirSync(join(tmpDir, '.git', 'hooks'));
+        writeFileSync(join(tmpDir, '.git', 'hooks', 'pre-commit'), 'other hook');
+        runHooks(tmpDir, { projectName: 'Test' }, { remove: true });
+        assert.ok(existsSync(join(tmpDir, '.git', 'hooks', 'pre-commit')));
+        assert.ok(logs.some(log => log.includes('not a DocGuard hook')));
+    });
+
+    it('skips existing non-DocGuard hooks when installing without force', () => {
+        mkdirSync(join(tmpDir, '.git'));
+        mkdirSync(join(tmpDir, '.git', 'hooks'));
+        writeFileSync(join(tmpDir, '.git', 'hooks', 'pre-commit'), 'other hook');
+        runHooks(tmpDir, { projectName: 'Test' }, { type: 'pre-commit' });
+        assert.strictEqual(readFileSync(join(tmpDir, '.git', 'hooks', 'pre-commit'), 'utf-8'), 'other hook');
+        assert.ok(logs.some(log => log.includes('existing hook found')));
+    });
+
+    it('overwrites existing hooks when installing with force', () => {
+        mkdirSync(join(tmpDir, '.git'));
+        mkdirSync(join(tmpDir, '.git', 'hooks'));
+        writeFileSync(join(tmpDir, '.git', 'hooks', 'pre-commit'), 'other hook');
+        runHooks(tmpDir, { projectName: 'Test' }, { type: 'pre-commit', force: true });
+        assert.ok(readFileSync(join(tmpDir, '.git', 'hooks', 'pre-commit'), 'utf-8').includes('DocGuard'));
+    });
+
+    it('skips existing DocGuard hooks when installing without force', () => {
+        mkdirSync(join(tmpDir, '.git'));
+        mkdirSync(join(tmpDir, '.git', 'hooks'));
+        writeFileSync(join(tmpDir, '.git', 'hooks', 'pre-commit'), 'DocGuard hook');
+        runHooks(tmpDir, { projectName: 'Test' }, { type: 'pre-commit' });
+        assert.strictEqual(readFileSync(join(tmpDir, '.git', 'hooks', 'pre-commit'), 'utf-8'), 'DocGuard hook');
+        assert.ok(logs.some(log => log.includes('DocGuard hook already installed')));
+    });
+});


### PR DESCRIPTION
🎯 **What:** The `runHooks` function in `cli/commands/hooks.mjs` lacked test coverage, creating a risk for future refactors and bug regressions. This PR adds a dedicated test suite for it.
📊 **Coverage:** The new tests comprehensively cover:
- Basic installation of default hooks (`pre-commit`, `pre-push`, `commit-msg`).
- Error paths: non-git directories and unknown hook types.
- `--list` flag behavior.
- `--remove` flag behavior (including correctly skipping non-DocGuard hooks).
- `--force` flag behavior when overwriting existing custom hooks.
- Skipping logic when encountering existing hooks without the force flag.
✨ **Result:** Test coverage for the hooks command is now thoroughly established. Tests use isolated temp directories and carefully mock CLI process utilities (`console.log`, `process.exit`), significantly increasing confidence in this area of the codebase and providing a safety net for future development.

---
*PR created automatically by Jules for task [7240923035500545169](https://jules.google.com/task/7240923035500545169) started by @raccioly*