### PR TITLE
🧪 Add tests for validateTodoTracking validator

### DIFF
--- a/tests/todo-tracking.test.mjs
+++ b/tests/todo-tracking.test.mjs
@@ -1,0 +1,73 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { validateTodoTracking } from '../cli/validators/todo-tracking.mjs';
+
+describe('Todo-Tracking Validator', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'docguard-test-todo-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('handles empty project gracefully', () => {
+    const result = validateTodoTracking(tmpDir, {});
+    assert.deepEqual(result, { errors: [], warnings: [], passed: 1, total: 1 });
+  });
+
+  it('warns about skipped test without explanation', () => {
+    writeFileSync(join(tmpDir, 'test1.test.mjs'), `
+      import { test } from 'node:test';
+      test.skip('skipped test', () => {});
+    `);
+
+    const result = validateTodoTracking(tmpDir, {});
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0], /Skipped test without explanation/);
+  });
+
+  it('passes skipped test with explanation', () => {
+    writeFileSync(join(tmpDir, 'test2.test.mjs'), `
+      import { test } from 'node:test';
+      // REASON: waiting for upstream fix
+      test.skip('skipped test', () => {});
+    `);
+
+    const result = validateTodoTracking(tmpDir, {});
+    assert.equal(result.warnings.length, 0);
+    assert.equal(result.passed, 3);
+  });
+
+  it('warns about untracked TODOs', () => {
+    writeFileSync(join(tmpDir, 'index.mjs'), `
+      // TODO: need to refactor this function
+      function myFunc() {}
+    `);
+
+    const result = validateTodoTracking(tmpDir, {});
+    assert.equal(result.warnings.length, 1);
+    assert.match(result.warnings[0], /Untracked TODO at index.mjs/);
+  });
+
+  it('passes when TODO is tracked in a roadmap', () => {
+    writeFileSync(join(tmpDir, 'index.mjs'), `
+      // TODO: need to refactor this function heavily for performance reasons
+      function myFunc() {}
+    `);
+
+    writeFileSync(join(tmpDir, 'ROADMAP.md'), `
+      Here is the roadmap:
+      - need to refactor this function heavily for performance reasons
+    `);
+
+    const result = validateTodoTracking(tmpDir, {});
+    assert.equal(result.warnings.length, 0);
+  });
+});


### PR DESCRIPTION
🎯 **What:**
Added missing test suite for `validateTodoTracking` function in `cli/validators/todo-tracking.mjs`.

📊 **Coverage:**
The new tests cover:
- Graceful handling of empty projects.
- Detection of skipped tests missing an explanation comment.
- Passing skipped tests that include a valid `// REASON:` comment.
- Detection of untracked `TODO`s in source code.
- Passing `TODO`s that are properly documented in a tracking file (e.g., `ROADMAP.md`).

✨ **Result:**
Improved test coverage, adding a reliable safety net for future refactoring of the Todo-Tracking validator logic.

---
*PR created automatically by Jules for task [4210443672174185141](https://jules.google.com/task/4210443672174185141) started by @raccioly*