### PR TITLE
🧪 [Testing improvement] Add tests for score --signals and ALCOA+ compliance

### DIFF
--- a/tests/commands.test.mjs
+++ b/tests/commands.test.mjs
@@ -140,6 +140,22 @@ describe('docguard score', () => {
     const output = run('score');
     assert.match(output, /Badge:.*CDD_Score/);
   });
+
+  it('outputs multi-signal breakdown with --signals and ALCOA+ compliance', () => {
+    const output = run('score --signals');
+    assert.match(output, /Multi-Signal Quality Breakdown/);
+    assert.match(output, /Composite: Σ\(signal_score × weight\)/);
+    assert.match(output, /Quality labels: HIGH/);
+    assert.match(output, /ALCOA\+ Compliance/);
+    assert.match(output, /FDA Data Integrity Framework/);
+  });
+
+  it('outputs ALCOA+ compliance by default', () => {
+    const output = run('score');
+    assert.match(output, /ALCOA\+ Compliance/);
+    assert.match(output, /FDA Data Integrity Framework/);
+  });
+
 });
 
 describe('docguard diff', () => {


### PR DESCRIPTION
🎯 **What:** Missing test coverage for the `--signals` flag and ALCOA+ compliance output in the `runScore` command.
📊 **Coverage:** Scenarios for executing `docguard score --signals` and verifying ALCOA+ output in both default and signals modes are now tested.
✨ **Result:** Increased test coverage for multi-signal quality breakdown and ALCOA+ calculations in `score.mjs`.

---
*PR created automatically by Jules for task [13457751852358288362](https://jules.google.com/task/13457751852358288362) started by @raccioly*