### PR TITLE
🎨 Palette: Add screen reader accessibility to score status bar item

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2024-05-18 - Avoid Workspace Artifacts During Code Replacement
+**Learning:** Writing temporary `.patch` files to the filesystem and forgetting to remove them causes blocking issues during code review because they pollute the repository root.
+**Action:** When using the `replace_with_git_merge_diff` tool, supply the `<<<<<<< SEARCH ... ======= ... >>>>>>> REPLACE` blocks directly via the tool's `merge_diff` argument. Do not write intermediate `.patch` files to the filesystem.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -213,6 +213,10 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.accessibilityInformation = {
+        label: 'CDD Score: Unknown. Click to see details.',
+        role: 'button'
+      };
       statusBarItem.show();
       return;
     }
@@ -232,6 +236,10 @@ async function refreshScore() {
 
     statusBarItem.text = `${icon} CDD: ${score}/100 (${grade})`;
     statusBarItem.tooltip = `CDD Score: ${score}/100 - ${tooltipStatus}\nClick to see details`;
+    statusBarItem.accessibilityInformation = {
+      label: `CDD Score: ${score} out of 100, ${tooltipStatus}. Click to see details.`,
+      role: 'button'
+    };
     statusBarItem.backgroundColor = score < threshold
       ? new vscode.ThemeColor('statusBarItem.warningBackground')
       : undefined;
@@ -243,6 +251,10 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.accessibilityInformation = {
+      label: 'CDD Score: Error. Click to see details.',
+      role: 'button'
+    };
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 What: Added the `accessibilityInformation` object to the VS Code extension's dynamic status bar item in all three calculation states (success, missing JSON, and error).
🎯 Why: To ensure screen readers properly announce the CDD score changes and its interactive nature (as a button) for visually impaired users. 
📸 Before/After: No visual change (metadata only).
♿ Accessibility: Provides proper ARIA labels and a button role to the dynamic VS Code status bar item, enabling accurate screen reader support.

---
*PR created automatically by Jules for task [10871097862110389610](https://jules.google.com/task/10871097862110389610) started by @raccioly*