### PR TITLE
🎨 Palette: Improve VS Code extension error state tooltips

### DIFF
--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -213,6 +213,8 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.tooltip = 'CDD Score: Unavailable (Could not parse output)\nClick to see details';
+      statusBarItem.backgroundColor = undefined;
       statusBarItem.show();
       return;
     }
@@ -243,6 +245,8 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.tooltip = `CDD Score: Error (${e.message})\nClick to see details`;
+    statusBarItem.backgroundColor = undefined;
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 What: Added context-aware tooltips and cleared background colors when the VS Code extension encounters an error fetching or parsing the CDD score.
🎯 Why: Previously, when an error occurred, the status bar showed a generic `$(shield) CDD: ?` state, but the tooltip remained stale or unhelpful, making it hard for users to understand why the score failed to load.
📸 Before/After: Before: Tooltip could be a stale score's details. After: Tooltip explains the error (e.g., "Could not parse output" or the specific exception message).
♿ Accessibility: Improves the clarity of the extension's feedback for error states.

---
*PR created automatically by Jules for task [7005746478264508428](https://jules.google.com/task/7005746478264508428) started by @raccioly*