### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in spec-kit initialization

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Found multiple instances where user-controlled inputs (`projectDir`, `filePath`) were interpolated directly into shell commands via `execSync` (e.g., `execSync(\`node "\${cliPath}" init --dir "\${projectDir}"\`)`).
 **Learning:** This is a classic command injection vulnerability. If `projectDir` contains shell metacharacters like `;`, `&&`, or `||`, it allows arbitrary command execution.
 **Prevention:** Always use `execFileSync` (or `execFile` for async) instead of `execSync` when executing commands with dynamic inputs. Pass arguments as an array to ensure they are passed directly to the executable without shell interpolation.
+
+## 2025-05-18 - [Command Injection via detectAIAgent in execSync]
+**Vulnerability:** Command Injection in `cli/commands/init.mjs` and `cli/ensure-skills.mjs`. The `detectAIAgent` function read configuration files (`init-options.json`) which could contain malicious inputs for the agent name. This unvalidated input was then interpolated directly into an `execSync` call via `aiFlag` (e.g., `specify init ... --ai ${detectedAgent}`).
+**Learning:** Even seemingly benign values extracted from config files (like an AI agent identifier) can become command injection vectors if the config is tampered with and the value is concatenated into a raw shell string execution.
+**Prevention:** Strictly enforce the use of `execFileSync` with explicitly separated argument arrays rather than concatenating CLI flags and values into a single command string, completely bypassing shell interpretation.

--- a/cli/commands/init.mjs
+++ b/cli/commands/init.mjs
@@ -206,6 +206,12 @@ export async function runInit(projectDir, config, flags) {
 
     // Detect which AI agent is in use (matches spec-kit's --ai flag)
     const detectedAgent = detectAIAgent(projectDir);
+    // Security: Validate AI agent identifier to prevent command injection
+    // Only allow alphanumeric characters and hyphens
+    if (detectedAgent && !/^[a-zA-Z0-9-]+$/.test(detectedAgent)) {
+      throw new Error(`Invalid AI agent identifier: ${detectedAgent}`);
+    }
+
     const aiFlag = detectedAgent
       ? `--ai ${detectedAgent}`
       : '--ai generic --ai-commands-dir .agent/commands/';

--- a/cli/ensure-skills.mjs
+++ b/cli/ensure-skills.mjs
@@ -187,6 +187,12 @@ export function ensureSpecKit(projectDir, flags = {}) {
     }
     try {
       const detectedAgent = detectAIAgent(projectDir);
+      // Security: Validate AI agent identifier to prevent command injection
+      // Only allow alphanumeric characters and hyphens
+      if (detectedAgent && !/^[a-zA-Z0-9-]+$/.test(detectedAgent)) {
+        throw new Error(`Invalid AI agent identifier: ${detectedAgent}`);
+      }
+
       const aiFlag = detectedAgent
         ? `--ai ${detectedAgent}`
         : '--ai generic --ai-commands-dir .agent/commands/';

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,16 +1,16 @@
-🎯 **What:**
-Added a comprehensive test suite for the `validateTraceability` validator located in `cli/validators/traceability.mjs`.
+🚨 **Severity:** CRITICAL
 
-📊 **Coverage:**
-The new test file `tests/traceability.test.mjs` thoroughly tests the following scenarios:
-- Graceful handling of missing `docs-canonical` directory.
-- Successful source traceability validation mapping requirements to source files.
-- Missing required documents (`ARCHITECTURE.md` missing).
-- Unlinked documents (document exists but source code missing).
-- Orphaned documents (exists but not declared in required docs).
-- Successful Requirement ID traceability testing mapped to mock tests.
-- Missing test coverage for explicitly tracked Requirement IDs.
-- Orphaned test references tracking Requirement IDs that don't exist in docs.
+💡 **Vulnerability:**
+A command injection vulnerability existed in `cli/commands/init.mjs` and `cli/ensure-skills.mjs`. The `detectAIAgent` function read configuration files (`init-options.json` or `.agent/`) to determine the active AI agent. This unvalidated input was then directly interpolated into a shell execution string via `execSync` (`specify init ... --ai ${detectedAgent}`). An attacker or a maliciously crafted `.specify/init-options.json` could execute arbitrary shell commands.
 
-✨ **Result:**
-The codebase now ensures regressions will not occur when modifying the traceability V-Model logic and validates that the canonical-driven development workflows are correctly verified. Test suite successfully passes 8 new tests on `node:test`.
+🎯 **Impact:**
+If a user cloned a repository containing a maliciously crafted `.specify/init-options.json` (e.g., `{"ai": "hello; echo 'pwned'"}`) and ran DocGuard, the injected shell commands would be executed on their local machine with the privileges of the running Node process.
+
+🔧 **Fix:**
+Added strict regex input validation (`/^[a-zA-Z0-9-]+$/`) against the `detectedAgent` value immediately after it is extracted, throwing a clear error if malicious characters (like semicolons, pipes, or quotes) are detected before any shell interpolation occurs. Also documented the vector in `.jules/sentinel.md`.
+
+✅ **Verification:**
+1. Manually craft a malicious `.specify/init-options.json` with an injection payload like `; rm -rf /`.
+2. Run `pnpm start init` or an auto-init trigger.
+3. Verify the CLI throws `Error: Invalid AI agent identifier` instead of executing the payload.
+4. Run `pnpm test` to ensure all tests continue to pass.


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:**
A command injection vulnerability existed in `cli/commands/init.mjs` and `cli/ensure-skills.mjs`. The `detectAIAgent` function read configuration files (`init-options.json` or `.agent/`) to determine the active AI agent. This unvalidated input was then directly interpolated into a shell execution string via `execSync` (`specify init ... --ai ${detectedAgent}`). An attacker or a maliciously crafted `.specify/init-options.json` could execute arbitrary shell commands.

🎯 **Impact:**
If a user cloned a repository containing a maliciously crafted `.specify/init-options.json` (e.g., `{"ai": "hello; echo 'pwned'"}`) and ran DocGuard, the injected shell commands would be executed on their local machine with the privileges of the running Node process.

🔧 **Fix:**
Added strict regex input validation (`/^[a-zA-Z0-9-]+$/`) against the `detectedAgent` value immediately after it is extracted, throwing a clear error if malicious characters (like semicolons, pipes, or quotes) are detected before any shell interpolation occurs. Also documented the vector in `.jules/sentinel.md`.

✅ **Verification:**
1. Manually craft a malicious `.specify/init-options.json` with an injection payload like `; rm -rf /`.
2. Run `pnpm start init` or an auto-init trigger.
3. Verify the CLI throws `Error: Invalid AI agent identifier` instead of executing the payload.
4. Run `pnpm test` to ensure all tests continue to pass.

---
*PR created automatically by Jules for task [8761648448539098190](https://jules.google.com/task/8761648448539098190) started by @raccioly*