### PR TITLE
🎨 Palette: Add context-aware tooltips and error backgrounds to VS Code status bar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2024-05-17 - Error State Background Colors
+**Learning:** Adding a red background color (`statusBarItem.errorBackground`) directly to a VS Code status bar item on error state (like failed parsing or CLI execution) dramatically improves the visibility of failures compared to just updating the icon and text.
+**Action:** When a critical error prevents an extension from functioning, map `statusBarItem.backgroundColor` to `new vscode.ThemeColor('statusBarItem.errorBackground')` along with the context-aware tooltip to guide the user.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -213,6 +213,8 @@ async function refreshScore() {
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.tooltip = 'Could not parse score output. Click to view logs.';
+      statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
       statusBarItem.show();
       return;
     }
@@ -243,6 +245,8 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.tooltip = `Error refreshing score: ${e.message}`;
+    statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 **What:** Added `statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground')` and context-aware tooltips (e.g. `'Could not parse score output. Click to view logs.'` or `Error refreshing score: ${e.message}`) when `refreshScore` encounters an error.

🎯 **Why:** Previously, if the CLI failed or threw an error, the status bar simply displayed `$(shield) CDD: ?`. The user had no visual cue that an error occurred, nor any guidance on why. Adding a red background and a detailed tooltip immediately signals a problem and points them to the logs.

📸 **Before/After:**
*   **Before:** Silent failure; status bar remains default color with text `$(shield) CDD: ?` and the original static tooltip.
*   **After:** Status bar turns red, showing `$(shield) CDD: ?`, and hovering over it displays "Could not parse score output..." or the specific error message.

♿ **Accessibility:** This provides stronger visual and semantic feedback for error states within the VS Code UI, assisting developers who may miss small icon changes.

---
*PR created automatically by Jules for task [7056885486629444255](https://jules.google.com/task/7056885486629444255) started by @raccioly*