### PR TITLE
🎨 Palette: [UX improvement] Add context-aware tooltips to VS Code extension error states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2024-05-18 - Resetting Status Bar State on Success
+**Learning:** When updating VS Code extension `statusBarItem` properties (like `backgroundColor` or `tooltip`) to indicate error states, if the success path does not explicitly reset them to `undefined`, the visual error states will persist indefinitely, causing UX confusion.
+**Action:** Always verify that error states are explicitly cleared (e.g., set to `undefined`) at the beginning of an update function or explicitly within success branches.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **VS Code Extension: Error Context** — Added explicit tooltips and warning backgrounds to the VS Code status bar item when CDD scores fail to refresh or parse, making error states clearer to the user.
+
 ## [0.9.11] - 2026-03-18
 
 ### Added

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -206,13 +206,25 @@ function execSpecguard(workspaceDir, args) {
 
 async function refreshScore() {
   const dir = getWorkspaceDir();
-  if (!dir) return;
+  if (!dir) {
+    if (statusBarItem) {
+      statusBarItem.backgroundColor = undefined;
+      statusBarItem.tooltip = undefined;
+    }
+    return;
+  }
+
+  // Optimistically reset background color and tooltip before refresh
+  statusBarItem.backgroundColor = undefined;
+  statusBarItem.tooltip = undefined;
 
   try {
     const output = execSpecguard(dir, 'score --format json');
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.tooltip = 'CDD Score: Unavailable (Failed to parse output)';
+      statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
       statusBarItem.show();
       return;
     }
@@ -243,6 +255,8 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.tooltip = 'CDD Score: Error (Click to retry)';
+    statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 What: Added explicit context-aware tooltips and warning backgrounds to the VS Code status bar item when the CDD score fails to refresh or parse. Added defensive logic to clear the error state on subsequent successful refreshes.
🎯 Why: Previously, if the extension encountered an error while refreshing the score, it would just show `CDD: ?` with no context. Providing clear error tooltips (e.g., "Failed to parse output" or "Click to retry") alongside standard VS Code error background colors makes the UI significantly more informative and intuitive.
📸 Before/After: Before, a `?` appeared statically with no background color change. After, the background turns red (using `statusBarItem.errorBackground`) with a tooltip describing the failure type.
♿ Accessibility: Improves accessibility by pairing visual error indicators (background color) with descriptive, screen-reader accessible text (tooltip) so users don't have to guess why a state failed.

---
*PR created automatically by Jules for task [9391095168534969630](https://jules.google.com/task/9391095168534969630) started by @raccioly*