### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in specify init execution

### DIFF
--- a/cli/commands/init.mjs
+++ b/cli/commands/init.mjs
@@ -13,7 +13,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync } from 
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createInterface } from 'node:readline';
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { c, PROFILES } from '../shared.mjs';
 import { ensureSkills, detectAgentMode, detectAIAgent, isSpecKitAvailable, isSpecKitInitialized, getDetectedAgent } from '../ensure-skills.mjs';
 
@@ -207,14 +207,16 @@ export async function runInit(projectDir, config, flags) {
     // Detect which AI agent is in use (matches spec-kit's --ai flag)
     const detectedAgent = detectAIAgent(projectDir);
     const aiFlag = detectedAgent
-      ? `--ai ${detectedAgent}`
-      : '--ai generic --ai-commands-dir .agent/commands/';
+      ? ['--ai', detectedAgent]
+      : ['--ai', 'generic', '--ai-commands-dir', '.agent/commands/'];
 
     console.log(`  ${c.dim}Running specify init (agent: ${detectedAgent || 'generic'})...${c.reset}`);
     try {
-      const scriptFlag = process.platform === 'win32' ? '--script ps' : '--script sh';
-      execSync(
-        `specify init --here --force ${aiFlag} --ai-skills --ignore-agent-tools --no-git ${scriptFlag}`,
+      const scriptFlag = process.platform === 'win32' ? ['--script', 'ps'] : ['--script', 'sh'];
+      const executable = process.platform === 'win32' ? 'specify.cmd' : 'specify';
+      execFileSync(
+        executable,
+        ['init', '--here', '--force', ...aiFlag, '--ai-skills', '--ignore-agent-tools', '--no-git', ...scriptFlag],
         { cwd: projectDir, encoding: 'utf-8', stdio: 'pipe', timeout: 30000 }
       );
       console.log(`  ${c.green}✅${c.reset} Spec Kit initialized ${c.dim}(.specify/, spec-kit skills, agent: ${detectedAgent || 'generic'})${c.reset}`);

--- a/cli/ensure-skills.mjs
+++ b/cli/ensure-skills.mjs
@@ -13,7 +13,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { c } from './shared.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -188,11 +188,13 @@ export function ensureSpecKit(projectDir, flags = {}) {
     try {
       const detectedAgent = detectAIAgent(projectDir);
       const aiFlag = detectedAgent
-        ? `--ai ${detectedAgent}`
-        : '--ai generic --ai-commands-dir .agent/commands/';
-      const scriptFlag = process.platform === 'win32' ? '--script ps' : '--script sh';
-      execSync(
-        `specify init --here --force ${aiFlag} --ai-skills --ignore-agent-tools --no-git ${scriptFlag}`,
+        ? ['--ai', detectedAgent]
+        : ['--ai', 'generic', '--ai-commands-dir', '.agent/commands/'];
+      const scriptFlag = process.platform === 'win32' ? ['--script', 'ps'] : ['--script', 'sh'];
+      const executable = process.platform === 'win32' ? 'specify.cmd' : 'specify';
+      execFileSync(
+        executable,
+        ['init', '--here', '--force', ...aiFlag, '--ai-skills', '--ignore-agent-tools', '--no-git', ...scriptFlag],
         { cwd: projectDir, encoding: 'utf-8', stdio: 'pipe', timeout: 30000 }
       );
       if (!silent) {


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Found instances where dynamically determined parameters (like `detectedAgent` from `.specify/agent` or other user-controlled dotfiles) were being interpolated directly into a shell command using `execSync(\`specify init --ai \${detectedAgent} ...\`)`. This allowed for arbitrary shell command injection if a malicious repository contained crafted strings with shell metacharacters (e.g. `; rm -rf /`).
🎯 **Impact:** Remote Code Execution (RCE) on the developer's machine when running the `docguard init` command in a compromised repository.
🔧 **Fix:** Refactored the command execution to use `execFileSync` and pass arguments securely as an array, completely bypassing the shell. Handled cross-platform execution by explicitly resolving `specify.cmd` on Windows.
✅ **Verification:** Verified via `npm test` that all CLI tests pass and execution logic remains functionally equivalent without regression.

---
*PR created automatically by Jules for task [418030273248106602](https://jules.google.com/task/418030273248106602) started by @raccioly*