### PR TITLE
⚡ Bolt: Optimize Set to Array spreads in diff commands

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - [O(N*M) String Overhead]
 **Learning:** To prevent N^2 performance bottlenecks in nested loops (such as comparing a list of items against multiple documents), precomputing expensive operations like `.toLowerCase()` during the initial file load or mapping phase avoids redundant $O(N \times M)$ overhead.
 **Action:** Precompute expensive string operations and property lookups (like `.toLowerCase()` and `.substring()`) outside of inner loops and during file load mapping phases to improve scaling.
+
+## 2024-05-20 - Array Allocation Bottlenecks in Filter-Some Loops
+**Learning:** Destructuring and spreading Sets into arrays inside `Array.prototype.filter()` loops that contain nested `Array.prototype.some()` checks creates an O(N*M) algorithmic bottleneck due to redundant array allocations on every iteration.
+**Action:** Always precompute Sets into array variables outside of `filter()` and `map()` loops when performing iterative inclusion checks. This eliminates redundant allocations and provides a substantial performance win in large codebases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -249,6 +249,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Trace no longer hardcodes all 6 docs — only evaluates what the user's config requires.
 
+## [Unreleased]
+
+### Changed
+- Refactored `diffRoutes` and `diffEntities` in `cli/commands/diff.mjs` to eliminate redundant O(N*M) array allocations when executing inclusion checks.
+
 ## [0.7.1] - 2026-03-13
 
 ### Added

--- a/cli/commands/diff.mjs
+++ b/cli/commands/diff.mjs
@@ -128,17 +128,20 @@ function diffRoutes(dir) {
     }
   }
 
+  const docRoutesArr = [...docRoutes];
+  const codeRoutesArr = [...codeRoutes];
+
   return {
     title: 'API Routes',
     icon: '🛣️',
-    onlyInDocs: [...docRoutes].filter(r => ![...codeRoutes].some(cr => cr.includes(r.replace(/\//g, '/')))),
-    onlyInCode: [...codeRoutes].filter(cr => {
+    onlyInDocs: docRoutesArr.filter(r => !codeRoutesArr.some(cr => cr.includes(r.replace(/\//g, '/')))),
+    onlyInCode: codeRoutesArr.filter(cr => {
       const name = basename(cr, extname(cr));
-      return ![...docRoutes].some(dr => dr.includes(name));
+      return !docRoutesArr.some(dr => dr.includes(name));
     }),
-    matched: [...codeRoutes].filter(cr => {
+    matched: codeRoutesArr.filter(cr => {
       const name = basename(cr, extname(cr));
-      return [...docRoutes].some(dr => dr.includes(name));
+      return docRoutesArr.some(dr => dr.includes(name));
     }),
   };
 }
@@ -231,12 +234,15 @@ function diffEntities(dir) {
     }
   }
 
+  const docEntitiesArr = [...docEntities];
+  const codeEntitiesArr = [...codeEntities];
+
   return {
     title: 'Data Entities',
     icon: '🗃️',
-    onlyInDocs: [...docEntities].filter(d => ![...codeEntities].some(ce => ce.includes(d) || d.includes(ce))),
-    onlyInCode: [...codeEntities].filter(ce => ![...docEntities].some(d => d.includes(ce) || ce.includes(d))),
-    matched: [...codeEntities].filter(ce => [...docEntities].some(d => d.includes(ce) || ce.includes(d))),
+    onlyInDocs: docEntitiesArr.filter(d => !codeEntitiesArr.some(ce => ce.includes(d) || d.includes(ce))),
+    onlyInCode: codeEntitiesArr.filter(ce => !docEntitiesArr.some(d => d.includes(ce) || ce.includes(d))),
+    matched: codeEntitiesArr.filter(ce => docEntitiesArr.some(d => d.includes(ce) || ce.includes(d))),
   };
 }
 


### PR DESCRIPTION
💡 What: Extracting `[...docRoutes]`, `[...codeRoutes]`, `[...docEntities]`, and `[...codeEntities]` Set-to-Array spread operations into variables outside of `.filter().some()` nested loops.

🎯 Why: In large codebases, the previous implementation created fresh, redundant array allocations for every loop iteration, creating an O(N*M) algorithmic memory and speed bottleneck.

📊 Impact: Significantly speeds up array filtering and checks during execution of the `diff` command by stopping hundreds to thousands of redundant memory allocations.

🔬 Measurement: Verified using `pnpm test` ensuring exact functional parity with original implementations without introducing regressions.

---
*PR created automatically by Jules for task [7741634704256623436](https://jules.google.com/task/7741634704256623436) started by @raccioly*