### PR TITLE
🎨 Palette: Improve status bar error and warning states

### DIFF
--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -212,7 +212,9 @@ async function refreshScore() {
     const output = execSpecguard(dir, 'score --format json');
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
-      statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.text = '$(warning) CDD: ?';
+      statusBarItem.tooltip = 'Could not parse CDD score output. Ensure docguard is installed.';
+      statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
       statusBarItem.show();
       return;
     }
@@ -242,7 +244,9 @@ async function refreshScore() {
 
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
-    statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.text = '$(error) CDD: Error';
+    statusBarItem.tooltip = `CDD Score Error: ${e.message}`;
+    statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 What: Replaced the generic `$(shield) CDD: ?` state when the CDD output is unparseable or fails with clear warning/error states. This includes context-aware tooltips explaining the error and the utilization of standard VS Code theme colors (`warningBackground` and `errorBackground`) to provide immediate, visible feedback in the status bar.
🎯 Why: Previously, when the underlying `specguard` CLI execution failed or timed out, the extension silently swallowed the issue and displayed a generic grey shield with a question mark. Developers would not know if they were missing a `specguard` installation or if an error had occurred unless they opened the output logs.
📸 Before/After: Before, an error would show `$(shield) CDD: ?`. Now, an error will show `$(error) CDD: Error` with an error background, and unparseable JSON will show `$(warning) CDD: ?` with a warning background. Both states have explicit informative tooltips.
♿ Accessibility: Uses VS Code's native theme properties (`statusBarItem.warningBackground` and `statusBarItem.errorBackground`), which inherently respect user contrast themes and visual aid settings, unlike custom coloring.

---
*PR created automatically by Jules for task [6645431832026511294](https://jules.google.com/task/6645431832026511294) started by @raccioly*