### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in specify init

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Found multiple instances where user-controlled inputs (`projectDir`, `filePath`) were interpolated directly into shell commands via `execSync` (e.g., `execSync(\`node "\${cliPath}" init --dir "\${projectDir}"\`)`).
 **Learning:** This is a classic command injection vulnerability. If `projectDir` contains shell metacharacters like `;`, `&&`, or `||`, it allows arbitrary command execution.
 **Prevention:** Always use `execFileSync` (or `execFile` for async) instead of `execSync` when executing commands with dynamic inputs. Pass arguments as an array to ensure they are passed directly to the executable without shell interpolation.
+
+## 2025-05-18 - [execFileSync with Windows batch files]
+**Vulnerability:** Command injection was possible in `specify init` because `execSync` was being used with a dynamically constructed string that included user input (the extracted agent string).
+**Learning:** `execFileSync` cannot natively run `.cmd` or `.bat` files on Windows. If we switch to `execFileSync('specify.cmd', ...)` to prevent command injection, the process will fail without a shell wrapper. The safe way to invoke batch scripts cross-platform while preventing command injection is to explicitly use `cmd.exe /c` on Windows: `execFileSync('cmd.exe', ['/c', 'specify.cmd', ...args])`.
+**Prevention:** When refactoring `execSync` to `execFileSync` for cross-platform execution of `.cmd` files, remember to prefix the command with `cmd.exe /c` on Windows to avoid breaking the application on that OS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Security**: Fixed command injection vulnerabilities in `specify init` by safely using `execFileSync` and adding input validation (`cli/commands/init.mjs`, `cli/ensure-skills.mjs`).
+
 ## [0.9.11] - 2026-03-18
 
 ### Added

--- a/cli/commands/init.mjs
+++ b/cli/commands/init.mjs
@@ -13,7 +13,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync } from 
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createInterface } from 'node:readline';
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { c, PROFILES } from '../shared.mjs';
 import { ensureSkills, detectAgentMode, detectAIAgent, isSpecKitAvailable, isSpecKitInitialized, getDetectedAgent } from '../ensure-skills.mjs';
 
@@ -206,18 +206,26 @@ export async function runInit(projectDir, config, flags) {
 
     // Detect which AI agent is in use (matches spec-kit's --ai flag)
     const detectedAgent = detectAIAgent(projectDir);
-    const aiFlag = detectedAgent
-      ? `--ai ${detectedAgent}`
-      : '--ai generic --ai-commands-dir .agent/commands/';
 
-    console.log(`  ${c.dim}Running specify init (agent: ${detectedAgent || 'generic'})...${c.reset}`);
+    // Validate detectedAgent to prevent any unexpected payload
+    const isValidAgent = detectedAgent && /^[a-zA-Z0-9-]+$/.test(detectedAgent);
+    const safeAgent = isValidAgent ? detectedAgent : null;
+
+    const aiFlag = safeAgent
+      ? ['--ai', safeAgent]
+      : ['--ai', 'generic', '--ai-commands-dir', '.agent/commands/'];
+
+    console.log(`  ${c.dim}Running specify init (agent: ${safeAgent || 'generic'})...${c.reset}`);
     try {
-      const scriptFlag = process.platform === 'win32' ? '--script ps' : '--script sh';
-      execSync(
-        `specify init --here --force ${aiFlag} --ai-skills --ignore-agent-tools --no-git ${scriptFlag}`,
-        { cwd: projectDir, encoding: 'utf-8', stdio: 'pipe', timeout: 30000 }
-      );
-      console.log(`  ${c.green}✅${c.reset} Spec Kit initialized ${c.dim}(.specify/, spec-kit skills, agent: ${detectedAgent || 'generic'})${c.reset}`);
+      const scriptFlag = process.platform === 'win32' ? ['--script', 'ps'] : ['--script', 'sh'];
+      const specifyArgs = ['init', '--here', '--force', ...aiFlag, '--ai-skills', '--ignore-agent-tools', '--no-git', ...scriptFlag];
+
+      if (process.platform === 'win32') {
+        execFileSync('cmd.exe', ['/c', 'specify.cmd', ...specifyArgs], { cwd: projectDir, encoding: 'utf-8', stdio: 'pipe', timeout: 30000 });
+      } else {
+        execFileSync('specify', specifyArgs, { cwd: projectDir, encoding: 'utf-8', stdio: 'pipe', timeout: 30000 });
+      }
+      console.log(`  ${c.green}✅${c.reset} Spec Kit initialized ${c.dim}(.specify/, spec-kit skills, agent: ${safeAgent || 'generic'})${c.reset}`);
       created.push('.specify/ (spec-kit foundation)');
     } catch (err) {
       console.log(`  ${c.yellow}⚠️${c.reset}  Spec Kit init had issues ${c.dim}(continuing with DocGuard standalone)${c.reset}`);

--- a/cli/ensure-skills.mjs
+++ b/cli/ensure-skills.mjs
@@ -13,7 +13,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync } from 'node:fs';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { c } from './shared.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -130,8 +130,8 @@ export function detectAIAgent(projectDir) {
  */
 export function isSpecKitAvailable() {
   try {
-    const cmd = process.platform === 'win32' ? 'where specify' : 'which specify';
-    execSync(cmd, { encoding: 'utf-8', stdio: 'pipe', timeout: 3000 });
+    const cmd = process.platform === 'win32' ? 'where' : 'which';
+    execFileSync(cmd, ['specify'], { encoding: 'utf-8', stdio: 'pipe', timeout: 3000 });
     return true;
   } catch {
     return false;
@@ -187,14 +187,23 @@ export function ensureSpecKit(projectDir, flags = {}) {
     }
     try {
       const detectedAgent = detectAIAgent(projectDir);
-      const aiFlag = detectedAgent
-        ? `--ai ${detectedAgent}`
-        : '--ai generic --ai-commands-dir .agent/commands/';
-      const scriptFlag = process.platform === 'win32' ? '--script ps' : '--script sh';
-      execSync(
-        `specify init --here --force ${aiFlag} --ai-skills --ignore-agent-tools --no-git ${scriptFlag}`,
-        { cwd: projectDir, encoding: 'utf-8', stdio: 'pipe', timeout: 30000 }
-      );
+
+      // Validate detectedAgent to prevent any unexpected payload
+      const isValidAgent = detectedAgent && /^[a-zA-Z0-9-]+$/.test(detectedAgent);
+      const safeAgent = isValidAgent ? detectedAgent : null;
+
+      const aiFlag = safeAgent
+        ? ['--ai', safeAgent]
+        : ['--ai', 'generic', '--ai-commands-dir', '.agent/commands/'];
+
+      const scriptFlag = process.platform === 'win32' ? ['--script', 'ps'] : ['--script', 'sh'];
+      const specifyArgs = ['init', '--here', '--force', ...aiFlag, '--ai-skills', '--ignore-agent-tools', '--no-git', ...scriptFlag];
+
+      if (process.platform === 'win32') {
+        execFileSync('cmd.exe', ['/c', 'specify.cmd', ...specifyArgs], { cwd: projectDir, encoding: 'utf-8', stdio: 'pipe', timeout: 30000 });
+      } else {
+        execFileSync('specify', specifyArgs, { cwd: projectDir, encoding: 'utf-8', stdio: 'pipe', timeout: 30000 });
+      }
       if (!silent) {
         console.log(`  ${c.green}✅ Spec Kit initialized${c.reset} ${c.dim}(agent: ${detectedAgent || 'generic'}, 9 skills installed)${c.reset}\n`);
       }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command injection in `specify init` logic via unvalidated `detectedAgent` from filesystem signals.
🎯 Impact: Attackers could craft malicious files (like `.cursor`) containing shell metacharacters, allowing arbitrary code execution when `docguard init` is run.
🔧 Fix: Used `execFileSync` to safely pass arguments directly to the executable, avoiding shell interpolation entirely. Additionally added regex validation for the `aiFlag` to ensure it contains only expected characters, and properly handled Windows execution of `.cmd` files.
✅ Verification: Ran `node --test tests/*.test.mjs` and ensured 100% of tests passed successfully. Verified syntax with `node -c` on changed files.

---
*PR created automatically by Jules for task [7753636347519907687](https://jules.google.com/task/7753636347519907687) started by @raccioly*