### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in specify init

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,4 @@
-## 2025-05-18 - [Command Injection via execSync]
-**Vulnerability:** Found multiple instances where user-controlled inputs (`projectDir`, `filePath`) were interpolated directly into shell commands via `execSync` (e.g., `execSync(\`node "\${cliPath}" init --dir "\${projectDir}"\`)`).
-**Learning:** This is a classic command injection vulnerability. If `projectDir` contains shell metacharacters like `;`, `&&`, or `||`, it allows arbitrary command execution.
-**Prevention:** Always use `execFileSync` (or `execFile` for async) instead of `execSync` when executing commands with dynamic inputs. Pass arguments as an array to ensure they are passed directly to the executable without shell interpolation.
+## 2025-05-21 - Fix Command Injection in spec-kit initialize configuration parsing
+**Vulnerability:** The `ai` field in `.specify/init-options.json` was parsed and injected directly into a shell string executed by `execSync` (`specify init --here --force --ai ${opts.ai}`). This allowed a malicious local configuration file to achieve arbitrary command execution when developers ran CLI commands.
+**Learning:** Even though `execSync` is often used for fast prototyping, any dynamic data (even locally stored config files) fed into its shell string constitutes a command injection vulnerability. Attempting to fix this by switching to `execFileSync('cmd.exe', ['/c', ...args])` on Windows is still vulnerable to shell injection if the arguments are not validated.
+**Prevention:** Always validate parsed dynamic data against a strict regex allowlist (e.g., `/^[a-zA-Z0-9-]+$/`) if it must be used in a shell context.

--- a/cli/ensure-skills.mjs
+++ b/cli/ensure-skills.mjs
@@ -77,7 +77,11 @@ export function getDetectedAgent(projectDir) {
   if (existsSync(initOptions)) {
     try {
       const opts = JSON.parse(readFileSync(initOptions, 'utf-8'));
-      return opts.ai || null;
+      const aiVal = opts.ai || null;
+      if (aiVal && !/^[a-zA-Z0-9-]+$/.test(aiVal)) {
+        return null; // Defense-in-depth: Reject potentially malicious payload
+      }
+      return aiVal;
     } catch { /* ignore */ }
   }
   return null;


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Command Injection in `specify init` logic via `.specify/init-options.json`
🎯 Impact: An attacker could execute arbitrary commands on a victim's machine by committing a malicious `.specify/init-options.json` (e.g., `{"ai": "generic; touch /tmp/pwned"}`) to a repository. When the victim runs the CLI, the unsanitized `ai` value is passed into a shell command (`execSync`), achieving Code Execution.
🔧 Fix: Added a strict regex allowlist validation (`/^[a-zA-Z0-9-]+$/`) inside `getDetectedAgent()` in `cli/ensure-skills.mjs` to reject any strings containing shell metacharacters. If an invalid payload is found, it safely falls back to returning `null`.
✅ Verification: Created a malicious `init-options.json` locally and verified that the injected command was blocked and rejected, and verified all 175 tests continue to pass to ensure no regressions.

---
*PR created automatically by Jules for task [7837761899205884517](https://jules.google.com/task/7837761899205884517) started by @raccioly*