### PR TITLE
⚡ Bolt: Precompute arrays in diff command to avoid O(N*M) allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - [O(N*M) String Overhead]
 **Learning:** To prevent N^2 performance bottlenecks in nested loops (such as comparing a list of items against multiple documents), precomputing expensive operations like `.toLowerCase()` during the initial file load or mapping phase avoids redundant $O(N \times M)$ overhead.
 **Action:** Precompute expensive string operations and property lookups (like `.toLowerCase()` and `.substring()`) outside of inner loops and during file load mapping phases to improve scaling.
+
+## 2024-05-18 - [Avoid Redundant Array Allocations in Filters]
+**Learning:** Found redundant array spreads `[...set]` inside `.filter()` callbacks. This results in N allocations of size M in an $O(N \times M)$ iteration bottleneck when comparing elements.
+**Action:** Always precompute Sets into Array variables before entering `.filter()` or `.map()` loops when comparing multiple arrays.

--- a/cli/commands/diff.mjs
+++ b/cli/commands/diff.mjs
@@ -128,17 +128,20 @@ function diffRoutes(dir) {
     }
   }
 
+  const docRoutesArr = [...docRoutes];
+  const codeRoutesArr = [...codeRoutes];
+
   return {
     title: 'API Routes',
     icon: '🛣️',
-    onlyInDocs: [...docRoutes].filter(r => ![...codeRoutes].some(cr => cr.includes(r.replace(/\//g, '/')))),
-    onlyInCode: [...codeRoutes].filter(cr => {
+    onlyInDocs: docRoutesArr.filter(r => !codeRoutesArr.some(cr => cr.includes(r.replace(/\//g, '/')))),
+    onlyInCode: codeRoutesArr.filter(cr => {
       const name = basename(cr, extname(cr));
-      return ![...docRoutes].some(dr => dr.includes(name));
+      return !docRoutesArr.some(dr => dr.includes(name));
     }),
-    matched: [...codeRoutes].filter(cr => {
+    matched: codeRoutesArr.filter(cr => {
       const name = basename(cr, extname(cr));
-      return [...docRoutes].some(dr => dr.includes(name));
+      return docRoutesArr.some(dr => dr.includes(name));
     }),
   };
 }
@@ -231,12 +234,15 @@ function diffEntities(dir) {
     }
   }
 
+  const docEntitiesArr = [...docEntities];
+  const codeEntitiesArr = [...codeEntities];
+
   return {
     title: 'Data Entities',
     icon: '🗃️',
-    onlyInDocs: [...docEntities].filter(d => ![...codeEntities].some(ce => ce.includes(d) || d.includes(ce))),
-    onlyInCode: [...codeEntities].filter(ce => ![...docEntities].some(d => d.includes(ce) || ce.includes(d))),
-    matched: [...codeEntities].filter(ce => [...docEntities].some(d => d.includes(ce) || ce.includes(d))),
+    onlyInDocs: docEntitiesArr.filter(d => !codeEntitiesArr.some(ce => ce.includes(d) || d.includes(ce))),
+    onlyInCode: codeEntitiesArr.filter(ce => !docEntitiesArr.some(d => d.includes(ce) || ce.includes(d))),
+    matched: codeEntitiesArr.filter(ce => docEntitiesArr.some(d => d.includes(ce) || ce.includes(d))),
   };
 }
 


### PR DESCRIPTION
💡 What: Precomputed Set-to-Array spread operations (`[...docRoutes]`, `[...codeRoutes]`, etc.) by storing them in variables outside of the `.filter()` loops in `cli/commands/diff.mjs`.

🎯 Why: In the `diffRoutes` and `diffEntities` functions, the arrays were being spread inside the `.filter()` callback for every iteration. This created $N$ new array allocations of size $M$, resulting in an $O(N \times M)$ iteration bottleneck overhead.

📊 Impact: Significantly reduces memory allocations and iteration overhead during the execution of `docguard diff` or `docguard guard`, especially on large projects with extensive documentation and code bases.

🔬 Measurement: Verify the fix by running the test suite via `node --test tests/*.test.mjs`, ensuring no regressions in output or behavior. Expected execution times for large diff commands should demonstrate measurable speedups.

---
*PR created automatically by Jules for task [14029726696802533014](https://jules.google.com/task/14029726696802533014) started by @raccioly*