### PR TITLE
🎨 Palette: Improve status bar error state UX

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2024-05-21 - Status Bar Error State Persistence
+**Learning:** When updating VS Code extension `statusBarItem` properties like `backgroundColor` to indicate an error or warning, they must be explicitly reset to `undefined` on success, otherwise stale visual states (like red/orange backgrounds) can persist even after the error is resolved. Furthermore, error states should use context-aware icons (like `$(error)` or `$(question)`) and map the error message into the `tooltip` so users understand why the status bar is angry.
+**Action:** Always map dynamic visual properties (icons, tooltips, backgrounds) to appropriate context (error messages) and explicitly clear them during successful update cycles.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -208,11 +208,19 @@ async function refreshScore() {
   const dir = getWorkspaceDir();
   if (!dir) return;
 
+  // Reset states from any previous errors
+  if (statusBarItem) {
+    statusBarItem.backgroundColor = undefined;
+    statusBarItem.tooltip = undefined;
+  }
+
   try {
     const output = execSpecguard(dir, 'score --format json');
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
-      statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.text = '$(question) CDD: ?';
+      statusBarItem.tooltip = 'CDD score format invalid or unavailable';
+      statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
       statusBarItem.show();
       return;
     }
@@ -242,7 +250,9 @@ async function refreshScore() {
 
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
-    statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.text = '$(error) CDD: Error';
+    statusBarItem.tooltip = `Error refreshing CDD score: ${e.message}`;
+    statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 **What**: Improved the VS Code extension's status bar error and unavailable states. It now uses standard Theme Colors for warning and error backgrounds, adds context-aware icons, surfaces the error message in the tooltip, and explicitly clears properties on successful runs.
🎯 **Why**: When the CLI check fails (either returning invalid JSON or throwing an error), the status bar would just display a question mark without any tooltip explanation, making it hard to understand what went wrong. Furthermore, if it entered an error state, its visual modifications would persist forever even after subsequent successful checks.
📸 **Before/After**: N/A
♿ **Accessibility**: Provides much clearer context to developers about why the extension entered a failed state and resolves visual persistence issues that are confusing.

---
*PR created automatically by Jules for task [1991228375340794393](https://jules.google.com/task/1991228375340794393) started by @raccioly*