### PR TITLE
🎨 Palette: Improve Status Bar Error Feedback

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+## 2024-05-22 - Context-Aware Status Bar Feedback
+**Learning:** When updating VS Code extension `statusBarItem` properties to indicate error states, failing to reset dynamic properties (like `backgroundColor` and `tooltip`) at the start of the update cycle causes stale error visuals to persist even after the underlying issue is resolved.
+**Action:** Always explicitly reset dynamic status bar properties to `undefined` at the beginning of the update cycle, and provide informative tooltips paired with error background colors for context-aware error feedback.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -209,10 +209,14 @@ async function refreshScore() {
   if (!dir) return;
 
   try {
+    statusBarItem.backgroundColor = undefined;
+    statusBarItem.tooltip = undefined;
     const output = execSpecguard(dir, 'score --format json');
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
-      statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.text = '$(error) CDD: Error';
+      statusBarItem.tooltip = 'Could not parse score output';
+      statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
       statusBarItem.show();
       return;
     }
@@ -242,7 +246,9 @@ async function refreshScore() {
 
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
-    statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.text = '$(error) CDD: Error';
+    statusBarItem.tooltip = `Score refresh error: ${e.message}`;
+    statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 What: Updated the `refreshScore` function in the VS Code extension to explicitly reset and provide context-aware dynamic properties (`backgroundColor` and `tooltip`) for the status bar.
🎯 Why: Previously, when fetching or parsing the score failed, the status bar displayed an unhelpful `$(shield) CDD: ?` state. Now, it displays a standard `$(error)` icon with a red background and an informative tooltip explaining the specific error, making the interface more intuitive and resilient to stale error states.
📸 Before/After: Visual presentation for extension status bar correctly resets and shows explicit errors.
♿ Accessibility: Ensures that error states are explicitly communicated through multiple channels (icon, tooltip text, and color) instead of relying solely on an ambiguous question mark symbol.

---
*PR created automatically by Jules for task [8490424074980763494](https://jules.google.com/task/8490424074980763494) started by @raccioly*