### PR TITLE
🎨 Palette: Improve status bar error state feedback

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2024-04-16 - Reseting Visual State
+**Learning:** When applying dynamic properties (like `backgroundColor`) to VS Code extension status bar items in an error state, those visual changes become sticky if the success path fails to explicitly reset them (e.g., to `undefined`). This can cause the interface to stay perpetually in a state that looks like an error even after it recovers.
+**Action:** Always reset visual states explicitly in the success or initialization path of a state-updating UI function.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -209,10 +209,13 @@ async function refreshScore() {
   if (!dir) return;
 
   try {
+    statusBarItem.backgroundColor = undefined;
     const output = execSpecguard(dir, 'score --format json');
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
-      statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.text = '$(error) CDD: Error';
+      statusBarItem.tooltip = 'Could not parse CDD score output.';
+      statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
       statusBarItem.show();
       return;
     }
@@ -242,7 +245,9 @@ async function refreshScore() {
 
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
-    statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.text = '$(error) CDD: Error';
+    statusBarItem.tooltip = `Score refresh error: ${e.message}`;
+    statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 What: Add explicit status bar updates for score refresh errors.
🎯 Why: A static `$(shield) CDD: ?` state leaves users unaware that an error occurred. This changes it to clearly show `$(error) CDD: Error`, change the background to an error red, and set a tooltip containing the error message. Also ensures that the background is reset correctly when the refresh succeeds.
📸 Before/After: Visual changes to the status bar item.
♿ Accessibility: Increases the clarity and awareness of the error state through text, tooltip, and color changes.

---
*PR created automatically by Jules for task [16458623229086640836](https://jules.google.com/task/16458623229086640836) started by @raccioly*