### PR TITLE
🎨 Palette: Improve VS Code score refresh UX and error states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2024-04-16 - Synchronous Tasks and Error States in VS Code Extensions
+**Learning:** When executing synchronous tasks (like `execSync`) in VS Code extensions, the event loop blocks, preventing UI updates like loading spinners (`$(sync~spin)`) from rendering if fired immediately prior. Furthermore, using generic `$(shield)` icons for error states fails to communicate to users that something went wrong.
+**Action:** Always yield the event loop (e.g., `await new Promise(r => setTimeout(r, 0))`) after setting a loading state before a synchronous blocking call. Also, explicitly update the status bar with the `$(error)` icon, `errorBackground` color, and a context-aware error tooltip on exceptions.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -208,11 +208,22 @@ async function refreshScore() {
   const dir = getWorkspaceDir();
   if (!dir) return;
 
+  // Show loading state
+  statusBarItem.text = '$(sync~spin) CDD: ...';
+  statusBarItem.tooltip = 'Refreshing CDD Score...';
+  statusBarItem.backgroundColor = undefined;
+  statusBarItem.show();
+
+  // Yield to allow UI to update before synchronous execution
+  await new Promise(r => setTimeout(r, 0));
+
   try {
     const output = execSpecguard(dir, 'score --format json');
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
-      statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.text = '$(error) CDD: Error';
+      statusBarItem.tooltip = 'Failed to parse CDD score output. Click to see details.';
+      statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
       statusBarItem.show();
       return;
     }
@@ -242,7 +253,9 @@ async function refreshScore() {
 
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
-    statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.text = '$(error) CDD: Error';
+    statusBarItem.tooltip = `CDD refresh failed: ${e.message}\nClick to see details.`;
+    statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 **What:** Improved the UX of the `refreshScore` command in the VS Code extension by adding a proper loading spinner that actually renders before the synchronous `execSync` call, and overhauling the error states (JSON parsing and exceptions) to use the correct `$(error)` icon, red background color, and informative tooltips.

🎯 **Why:** Previously, the synchronous nature of the score refresh blocked the event loop, meaning users saw no visual feedback that a refresh was occurring. Furthermore, when the refresh failed, it fell back to a generic, unhelpful `$(shield) CDD: ?` state with no error coloring or explanation, making it difficult for users to know what went wrong.

📸 **Before/After:**
*   **Before (Loading):** No visual change until the command finishes.
*   **After (Loading):** Status bar displays `$(sync~spin) CDD: ...` with a "Refreshing..." tooltip.
*   **Before (Error):** `$(shield) CDD: ?` with no color.
*   **After (Error):** `$(error) CDD: Error` with standard VS Code red error background and a tooltip explaining the failure.

♿ **Accessibility:**
Provides clearer, context-aware visual feedback for both in-progress and error states, ensuring users aren't left guessing if the extension is working or why it failed.

---
*PR created automatically by Jules for task [8714180755206236189](https://jules.google.com/task/8714180755206236189) started by @raccioly*