### PR TITLE
🎨 Palette: [UX improvement] Add loading spinner and context-aware error states to VS Code status bar

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,8 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+## 2024-11-13 - Yielding the Event Loop for VS Code UI Updates
+
+**Learning:** When building VS Code extensions, updating `statusBarItem` properties (like adding a loading spinner or changing the background color) right before a synchronous block of code (like `execSync`) won't actually render if you don't yield the event loop. The UI thread gets blocked immediately. Furthermore, previously set styles (like `errorBackground`) can persist and incorrectly style the loading state.
+
+**Action:** Before running heavy synchronous operations, set the desired UI state, explicitly reset previous styling states (e.g., `backgroundColor = undefined`), and await an event loop yield (`await new Promise(r => setTimeout(r, 0));`) so that VS Code can flush UI updates to the renderer. And always provide informative tooltips alongside error states rather than ambiguous question marks.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -208,11 +208,24 @@ async function refreshScore() {
   const dir = getWorkspaceDir();
   if (!dir) return;
 
+  // UX Improvement: Show a loading state to indicate background work.
+  // Reset any previous background error colors so they don't incorrectly persist during load.
+  statusBarItem.text = '$(sync~spin) Refreshing CDD...';
+  statusBarItem.tooltip = 'Running SpecGuard CDD checks...';
+  statusBarItem.backgroundColor = undefined;
+  statusBarItem.show();
+
+  // Yield the event loop to allow VS Code to render the status bar updates before the
+  // synchronous child_process block kicks in.
+  await new Promise(r => setTimeout(r, 0));
+
   try {
     const output = execSpecguard(dir, 'score --format json');
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.tooltip = 'SpecGuard CDD check failed. Output could not be parsed. Check Output panel.';
+      statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
       statusBarItem.show();
       return;
     }
@@ -242,7 +255,9 @@ async function refreshScore() {
 
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
-    statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.text = '$(shield) CDD: Error';
+    statusBarItem.tooltip = `Error refreshing SpecGuard CDD score: ${e.message}`;
+    statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 What: Added a loading spinner to the VS Code status bar in `refreshScore` that displays while background CDD checks run. The event loop is explicitly yielded to ensure the spinner renders before the main thread blocks. Error states now have specific red background colors and informative tooltips instead of a generic question mark.

🎯 Why: Running synchronous CLI tasks via `execSync` locks the VS Code UI. Users previously had no feedback that the CDD score was refreshing. Additionally, if an error occurred, the status bar just showed a question mark without explanation, and sometimes inherited the previous background color.

📸 Before/After:
Before: `$(shield) CDD: ?` (no loading state, uninformative errors)
After: `$(sync~spin) Refreshing CDD...` (during load), `$(shield) CDD: Error` with red background and error tooltip.

♿ Accessibility: Ensures that status updates are visually communicated to the user, and that failure states explain what went wrong rather than relying on ambiguous iconography.

---
*PR created automatically by Jules for task [11873031017953862449](https://jules.google.com/task/11873031017953862449) started by @raccioly*