### PR TITLE
[supply-chain] Audit findings for 2026-05-25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Executed automated npm/PyPI supply-chain security audit. Findings saved to `reports/SUPPLY-CHAIN-AUDIT-2026-05-25.md`.
+
 ## [0.11.0] - 2026-05-22
 
 This release reshapes DocGuard from a documentation linter into an **AI-readable, always-current project memory builder** — for any language project, not just JS/web. The four-mode lifecycle (`generate → guard → sync → fix`) is now coherent end-to-end.

--- a/reports/SUPPLY-CHAIN-AUDIT-2026-05-25.md
+++ b/reports/SUPPLY-CHAIN-AUDIT-2026-05-25.md
@@ -1,0 +1,23 @@
+# Supply-Chain Security Audit Report
+Date: 2026-05-25
+
+## Phase 1: Known-Bad Packages
+- No known-bad packages found.
+
+## Phase 2: IOCs on Disk
+- No IOCs found.
+
+## Phase 3: Slopsquatting
+- No slopsquatting found.
+
+## Phase 4: Freshness Violations
+- **MEDIUM**: Floating version range found: `express@^4.18.0` in `./examples/01-express-api/package.json`
+- **MEDIUM**: Floating version range found: `@types/vscode@^1.80.0` in `./vscode-extension/package.json`
+
+## Phase 5: Install-Script Exposure
+- No install-script exposure found.
+
+## Phase 6: CI/CD Attack Surface
+- **HIGH**: Third-party action not pinned to commit SHA: `uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.8"` in `supply-chain.yml`
+- **HIGH**: Third-party action not pinned to commit SHA: `uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.8"` in `supply-chain.yml`
+- **MEDIUM**: Missing `permissions:` block in `ci.yml`


### PR DESCRIPTION
Executes an automated npm/PyPI supply-chain security audit.
Findings have been saved to `reports/SUPPLY-CHAIN-AUDIT-2026-05-25.md` according to the instructions in `SUPPLY-CHAIN-AUDIT.md`.

No package manager commands were executed as per the read-only constraint.
Also appended the audit event to `CHANGELOG.md` under the `## [Unreleased]` heading.

---
*PR created automatically by Jules for task [16153485262898379316](https://jules.google.com/task/16153485262898379316) started by @raccioly*