### PR TITLE
🎨 Palette: [UX improvement] Fix blocked status bar loading state and error feedback

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,9 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2024-05-26 - UI Updates Before Synchronous Blocking Operations
+
+**Learning:** When using VS Code's extension API, synchronous operations like `execSync` can block the main thread and prevent the UI from updating. For instance, setting a loading state (e.g., `$(sync~spin)`) immediately before calling `execSync` will not render the loading spinner to the user because the event loop does not get a chance to process the UI update before the thread is blocked. Furthermore, dynamic UI elements like `statusBarItem.backgroundColor` must be explicitly reset to `undefined` before new operations to clear stale states (such as an error background persisting into a loading or successful state).
+
+**Action:** Always yield the event loop (e.g., `await new Promise(r => setTimeout(r, 0));`) immediately after triggering a UI update and before starting any synchronous, thread-blocking operation. Ensure all dynamically styled UI element properties (like `backgroundColor` and `tooltip`) are explicitly cleared or set to appropriate defaults at the start of a new operation or within catch blocks.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -208,11 +208,20 @@ async function refreshScore() {
   const dir = getWorkspaceDir();
   if (!dir) return;
 
+  // Show loading state and yield event loop to ensure UI updates before blocking sync operation
+  statusBarItem.text = '$(sync~spin) CDD: ...';
+  statusBarItem.tooltip = 'Calculating CDD Score...';
+  statusBarItem.backgroundColor = undefined;
+  statusBarItem.show();
+  await new Promise(r => setTimeout(r, 0));
+
   try {
     const output = execSpecguard(dir, 'score --format json');
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.tooltip = 'CDD Score: Unknown';
+      statusBarItem.backgroundColor = undefined;
       statusBarItem.show();
       return;
     }
@@ -242,7 +251,9 @@ async function refreshScore() {
 
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
-    statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.text = '$(error) CDD: Error';
+    statusBarItem.tooltip = `Error calculating score: ${e.message}`;
+    statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 What: Added a dedicated `$(sync~spin)` loading state and tooltip to the VS Code status bar when calculating the CDD score, explicitly yielding the event loop before the synchronous `execSync` call blocks the thread. Also improved error feedback by assigning a red background and detailed tooltip on failure.
🎯 Why: Due to Node.js's single-threaded nature, running a synchronous command immediately after setting a UI state blocks the extension host before VS Code can render the change. This left the user with no visual feedback that a process was running. Additionally, error states would sometimes persist visually if background colors weren't explicitly reset.
📸 Before/After: Before, clicking refresh would seemingly do nothing for a few seconds until the new score popped in. Now, a spinning loading icon appears immediately. If an error occurs, it turns red with an explicit failure tooltip instead of silently printing to the output channel.
♿ Accessibility: Improved cognitive accessibility by ensuring the system always provides immediate, context-aware visual feedback for long-running and failing background tasks.

---
*PR created automatically by Jules for task [6450026556125782277](https://jules.google.com/task/6450026556125782277) started by @raccioly*