### PR TITLE
release: v0.22.0 — field-test fixes + Surface-Sync validator

### DIFF
--- a/.agent/skills/docguard-fix/SKILL.md
+++ b/.agent/skills/docguard-fix/SKILL.md
@@ -6,10 +6,10 @@ description: AI-driven documentation repair with structured research workflow, t
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.21.1
+  version: 0.22.0
   source: extensions/spec-kit-docguard/skills/docguard-fix
 ---
-<!-- docguard:version: 0.21.1 -->
+<!-- docguard:version: 0.22.0 -->
 
 # DocGuard Fix Skill
 

--- a/.agent/skills/docguard-guard/SKILL.md
+++ b/.agent/skills/docguard-guard/SKILL.md
@@ -7,10 +7,10 @@ description: Run DocGuard guard validation against Canonical-Driven Development 
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.21.1
+  version: 0.22.0
   source: extensions/spec-kit-docguard/skills/docguard-guard
 ---
-<!-- docguard:version: 0.21.1 -->
+<!-- docguard:version: 0.22.0 -->
 
 # DocGuard Guard Skill
 

--- a/.agent/skills/docguard-review/SKILL.md
+++ b/.agent/skills/docguard-review/SKILL.md
@@ -6,10 +6,10 @@ description: Cross-document consistency analysis and quality assessment. Perform
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.21.1
+  version: 0.22.0
   source: extensions/spec-kit-docguard/skills/docguard-review
 ---
-<!-- docguard:version: 0.21.1 -->
+<!-- docguard:version: 0.22.0 -->
 
 # DocGuard Review Skill
 

--- a/.agent/skills/docguard-score/SKILL.md
+++ b/.agent/skills/docguard-score/SKILL.md
@@ -6,10 +6,10 @@ description: CDD maturity assessment with category-aware improvement roadmap. Ru
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.21.1
+  version: 0.22.0
   source: extensions/spec-kit-docguard/skills/docguard-score
 ---
-<!-- docguard:version: 0.21.1 -->
+<!-- docguard:version: 0.22.0 -->
 
 # DocGuard Score Skill
 

--- a/.agent/skills/docguard-sync/SKILL.md
+++ b/.agent/skills/docguard-sync/SKILL.md
@@ -4,7 +4,7 @@ description: Keep canonical documentation ALWAYS UP TO DATE. Refreshes code-trut
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.21.1
+  version: 0.22.0
   source: extensions/spec-kit-docguard/skills/docguard-sync
 ---
 

--- a/.docguard.json
+++ b/.docguard.json
@@ -40,5 +40,40 @@
     "environment": true,
     "freshness": true
   },
-  "severity": {}
+  "severity": {},
+  "surfaceSync": {
+    "surfaces": [
+      {
+        "name": "commands",
+        "glob": "cli/commands/*.mjs",
+        "extract": "basename-no-ext",
+        "ignore": [
+          "agents", "hooks", "ci", "badge", "llms", "publish",
+          "setup", "impact"
+        ],
+        "docs": ["README.md"],
+        "section": "Usage"
+      },
+      {
+        "name": "validators",
+        "glob": "cli/validators/*.mjs",
+        "extract": "basename-no-ext",
+        "ignore": [
+          "drift",
+          "doc",
+          "doc-sections",
+          "drift-comments"
+        ],
+        "docs": ["README.md"],
+        "section": "Validators"
+      },
+      {
+        "name": "slash-commands",
+        "glob": "templates/commands/*.md",
+        "extract": "basename-no-ext",
+        "docs": ["README.md"],
+        "section": "Slash Commands"
+      }
+    ]
+  }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@
 | Command | Purpose |
 |---------|---------|
 | `diagnose` | **Primary** — identify issues + generate AI fix prompts |
-| `guard` | Validate project (CI gate) — 23 validators |
+| `guard` | Validate project (CI gate) — 24 validators |
 | `generate` | Reverse-engineer docs from code |
 | `fix --doc <name>` | AI prompt for specific document |
 | `score` | CDD maturity score (0-100) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — eight field-test bugs from v0.20.0
+
+Confirmed running v0.20.0 against two real projects (a Python codebase for
+the v0.20.0 cycle and a Next.js 15 App Router codebase). All eight were
+reproduced in the source, fixed surgically, and pinned with regression
+tests. Specs: `specs/004-v020-env-var-false-negative/`, `specs/005-hugocross-next-bugs/`.
+
+- **API-Surface emits wrong path for Next.js App Router with `src/` layout**
+  — `src/app/api/health/route.ts` was reported as `GET /app/api/health`
+  instead of `GET /api/health`. Caused the validator to fire two false
+  warnings per route (documented-missing + undocumented-in-code) on every
+  `src/app/api/` file. `cli/scanners/routes.mjs`.
+
+- **Freshness validator ignored `<!-- docguard:last-reviewed YYYY-MM-DD -->`**
+  — header was generated into every template, recommended in the freshness
+  fix text itself, checked by `score` for ALCOA+, but never read by
+  `validateFreshness`. The reviewer's explicit "I reviewed this" signal
+  had zero effect. The header now overrides the git-log fallback.
+  `cli/validators/freshness.mjs`.
+
+- **Environment-vars in pipe-table rows (no backticks) were treated as
+  undocumented** — projects using `| VAR_NAME | description | required |`
+  table syntax were silently flagged for every var. The doc parser only
+  matched backtick-quoted names; it now also extracts the first column of
+  markdown pipe-table rows. `cli/validators/environment.mjs`.
+
+- **Docs-Diff warning was unactionable** — emitted `"N documented but not
+  found in code"` with no filename. Now lists up to 5 paths inline with
+  `(+N more)` for the long-tail. `cli/validators/docs-diff.mjs`.
+
+- **Traceability ignored `// @doc` annotations AND missed Next.js App
+  Router paths** — templates told users `// @doc API-REFERENCE.md` would
+  link a source file to a canonical doc; the scanner never read the
+  annotation. Compound: the `API-REFERENCE.md` TRACE_MAP only matched
+  `routes/`, `controllers/`, `handlers/`, `openapi/swagger`, and
+  `middleware/` — none of which cover `app/api/`. Added an annotation
+  scanner (top-of-file, multi-language comment syntax) and an
+  `(app|pages)/api/` glob. `cli/validators/traceability.mjs`.
+
+- **`docguard upgrade --apply` silently broke Metrics-Consistency** — when
+  a CLI upgrade added or removed validators, the project's hardcoded "N
+  validators" counts in markdown went stale and the very next
+  `docguard guard` failed Metrics-Consistency. The user did nothing wrong.
+  `upgrade --apply` now prints an explicit nudge to run `fix --write`
+  using the just-installed binary (the current process holds the OLD CLI's
+  validator list, so it cannot apply the fix itself). `cli/commands/upgrade.mjs`.
+
+- **Python env-vars were never scanned at all** — `grepEnvUsage` walked
+  `.py` files but the regex list was JS-only (`process.env.*`,
+  `import.meta.env.*`). Every documented Python env var read as "in docs,
+  not in code". Added patterns for `os.environ["X"]`, `os.environ.get("X")`,
+  and `os.getenv("X")`. The `explain` command's claim that Python was
+  supported now actually holds. `cli/shared-source.mjs`.
+
+- **`docguard memory` "Accuracy" overlapped `docguard score` "Accuracy"
+  with different denominators** — same word, same project, wildly different
+  numbers. Renamed the per-claim metric in `memory` to **"Claim match
+  rate"** (matched claims / total claims) so it no longer collides with
+  the score's weighted accuracy axis across all signals. JSON field name
+  unchanged for backward compatibility. `cli/commands/memory.mjs`.
+
 ## [0.20.0] - 2026-05-26
 
 **Consolidation.** 21 user-facing commands become 13. The promise from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-05-28
+
 ### Added — Surface-Sync validator (item-level enumerable drift)
 
 `canonical-sync` already checks NUMERIC count claims in the README (ships

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Surface-Sync validator (item-level enumerable drift)
+
+`canonical-sync` already checks NUMERIC count claims in the README (ships
+N commands, N validators, mermaid diagram counts). But running the docguard
+repo through itself showed `canonical-sync` passing 3/3 while the README's
+command table silently omitted `demo` — the count matched, the table was
+wrong, the user hit "command not found" anyway. Count-level checks miss
+item-level drift.
+
+**Surface-Sync** is the item-level complement. For each configured surface
+(commands, validators, slash commands, templates — anything enumerable), it
+compares code-truth (from a glob) against the names appearing in table rows
+and bullet items in target docs. Warns on items present in code but missing
+from the doc, and on items listed in the doc but missing from code.
+
+Key behaviors:
+
+- **N/A by default.** Returns "nothing to validate" unless the project's
+  `.docguard.json` declares at least one surface under `surfaceSync.surfaces`.
+  Existing docguard projects upgrade safely with zero new noise.
+- **Section-scoped scanning.** Each surface can specify a `section` heading;
+  the validator restricts scanning to that section so a README containing
+  both a Commands table and a Validators table doesn't produce cross-table
+  false positives.
+- **Format-aware extraction.** Recognises documented entries written as
+  `` `name` ``, `**Name**`, `| `name` |`, `| N | **Name** |`, and bullet
+  items. Strips leading `docguard ` / `/` prefixes and folds case so README's
+  `**API-Surface**` matches file basename `api-surface.mjs`.
+- **Code-block immune.** Fenced code blocks are stripped before scanning so
+  shell examples don't inflate the documented set.
+- **`ignore` list per surface.** Known deprecation aliases, scaffolders
+  behind `init --with`, and display-name-vs-filename mismatches can be
+  silenced without disabling the surface entirely.
+
+Config shape (in `.docguard.json`):
+
+```json
+{
+  "surfaceSync": {
+    "surfaces": [
+      {
+        "name": "commands",
+        "glob": "cli/commands/*.mjs",
+        "extract": "basename-no-ext",
+        "ignore": ["setup", "impact"],
+        "docs": ["README.md"],
+        "section": "Usage"
+      }
+    ]
+  }
+}
+```
+
+DocGuard's own `.docguard.json` now declares three surfaces (commands,
+validators, slash-commands) so the project polices its own README on every
+`guard` run. Run `docguard explain surfaceSync` for fix guidance.
+
 ### Fixed — eight field-test bugs from v0.20.0
 
 Confirmed running v0.20.0 against two real projects (a Python codebase for

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ graph TD
     Commands --> setup["setup wizard"]
     Commands --> other["diff · init · fix · trace · impact · sync<br/>explain · memory · upgrade · agents · hooks · badge · ci · watch"]
 
-    guard --> Validators["Validators (23)"]
+    guard --> Validators["Validators (24)"]
     generate --> Scanners["Scanners (4)<br/>routes · schemas · doc-tools · speckit"]
     score --> Scoring["Weighted Scoring<br/>8 categories"]
     diagnose --> Validators
@@ -95,7 +95,7 @@ graph TD
 Recent highlights across the v0.16 → v0.19 line:
 
 - **`docguard explain <validator>`** — `docguard explain freshness` prints purpose, rules, common
-  failures, and fix recipes for any of the 23 validators. No need to dig into source.
+  failures, and fix recipes for any of the 24 validators. No need to dig into source.
 - **`docguard memory --diff`** — surface what changed in your canonical docs between two refs
   (`HEAD~10..HEAD` by default). Great for code review and changelog drafting.
 - **`docguard score --diff`** — see exactly which validators moved the score up or down between
@@ -237,7 +237,7 @@ DocGuard is a [community extension](https://github.com/github/spec-kit/blob/main
 specify extension add docguard
 ```
 
-This installs DocGuard's slash commands (`/docguard.guard`, `/docguard.review`, `/docguard.fix`, `/docguard.score`) into your AI agent's command palette.
+This installs DocGuard's slash commands (`/docguard.init`, `/docguard.guard`, `/docguard.review`, `/docguard.fix`, `/docguard.update`) into your AI agent's command palette.
 
 ---
 
@@ -250,7 +250,7 @@ DocGuard ships **14 commands** (the "Daily 5" + 9 situational tools, including t
 | Command | What It Does |
 |:--------|:-------------|
 | `init`  | Bootstrap a project (`--wizard` for interactive · `--with <name>` for scaffolders) |
-| `guard` | Validate against canonical docs — 23 validators |
+| `guard` | Validate against canonical docs — 24 validators |
 | `diff`  | Show gaps between docs and code (`--since <ref>` for impact mode) |
 | `sync`  | Refresh code-truth doc sections — keeps memory always up to date |
 | `score` | CDD maturity score (0-100; `--diff` for delta between refs) |
@@ -259,6 +259,7 @@ DocGuard ships **14 commands** (the "Daily 5" + 9 situational tools, including t
 
 | Command | Purpose |
 |:--------|:--------|
+| `demo` | Zero-install showcase — runs guard against a baked-in drifting fixture (`npx docguard-cli demo`) |
 | `diagnose` | AI orchestrator — guard → emit fix prompts in one command |
 | `fix` | Generate AI fix instructions for specific docs (`--doc <name> --format prompt`) |
 | `fix --write` | Apply deterministic fixes (no AI — version bumps, counts, anchors, sections) |
@@ -343,7 +344,7 @@ $ npx docguard-cli generate
 
 ## 🔍 Validators
 
-DocGuard runs **23 automated validators** on every `guard` check. Every one is **language-aware** as of v0.16 — patterns for Python (`test_*.py`), Rust (`tests/*.rs`), Go (`*_test.go`), Java (`*Test.java`), Ruby (`*_spec.rb`), PHP, and JS/TS all match.
+DocGuard runs **24 automated validators** on every `guard` check. Every one is **language-aware** as of v0.16 — patterns for Python (`test_*.py`), Rust (`tests/*.rs`), Go (`*_test.go`), Java (`*Test.java`), Ruby (`*_spec.rb`), PHP, and JS/TS all match.
 
 | # | Validator | What It Checks | Default |
 |:--|:----------|:--------------|:--------|
@@ -370,6 +371,7 @@ DocGuard runs **23 automated validators** on every `guard` check. Every one is *
 | 21 | **Generated-Staleness** | `source=code` sections match scanner output; `status: draft` doc age | ✅ On |
 | 22 | **Canonical-Sync** | DocGuard's own README count claims match code-truth (DocGuard repo only — N/A elsewhere) | ✅ On |
 | 23 | **Metrics-Consistency** | Hardcoded numbers match actual counts | ✅ On |
+| 24 | **Surface-Sync** | Item-level enumerable drift — names in doc tables/lists (commands, validators, etc.) match code-truth (opt-in via `surfaceSync.surfaces`; N/A unless configured) | ✅ On |
 
 **Per-validator controls** (in `.docguard.json`):
 ```json
@@ -437,10 +439,11 @@ DocGuard provides AI agent slash commands for integrated workflows. Installed au
 
 | Command | What It Does |
 |:--------|:-------------|
-| `/docguard.guard` | Run quality validation — check all 23 validators |
+| `/docguard.init` | Initialize Canonical-Driven Development in a new or existing project |
+| `/docguard.guard` | Run quality validation — check all 24 validators |
 | `/docguard.review` | Analyze doc quality and suggest improvements |
 | `/docguard.fix` | Generate targeted fix prompts for specific issues |
-| `/docguard.score` | Show CDD maturity score with category breakdown |
+| `/docguard.update` | Update canonical docs after code changes — detect drift and sync documentation |
 
 These commands are installed into your AI agent's command directory:
 

--- a/cli/commands/explain.mjs
+++ b/cli/commands/explain.mjs
@@ -150,6 +150,17 @@ const EXPLAINERS = {
     example: 'AGENTS.md says "22 validators" and `docguard guard` shows 22 active validators',
     standard: 'CDD principle: documented metrics match reality',
   },
+  surfaceSync: {
+    title: 'Surface-Sync — every code-derived list entry is documented',
+    what: 'Item-level check (complementing canonical-sync\'s count-level check). For each configured surface (e.g. commands → `cli/commands/*.mjs`), compares the discovered files against the names appearing in table rows / bullet lists in target docs (README.md, AGENTS.md). Warns when a code item is missing from the doc, or a doc item is missing from code.',
+    why:  'Counts can match while lists drift — README claimed "14 commands" while the table only listed 13 (demo was missing). Count validators celebrated; users hit "command not found" anyway. This check catches that case.',
+    triggers: [
+      ['Surface "X" drift: N in code but missing from README.md', 'Add the missing items to the relevant table / bullet list in the target doc. Or, if intentional (deprecation alias, scaffolder behind --with), add the names to the surface\'s `ignore` list in .docguard.json.'],
+      ['Surface "X" drift: N listed in README.md but not found in code', 'A documented item no longer exists in code. Either remove it from the doc (it was deleted) or restore the file/command (it was deleted by mistake).'],
+    ],
+    example: '`cli/commands/demo.mjs` exists and `| `demo` | Zero-install preview |` appears in README.md\'s commands table',
+    standard: 'CDD principle: documented surfaces match implemented surfaces',
+  },
   crossReference: {
     title: 'Cross-Reference — internal markdown links resolve',
     what: 'Scans canonical docs for `[text](./OTHER.md#anchor)` and `#anchor` links. Verifies the target file exists and the anchor matches a heading.',

--- a/cli/commands/guard.mjs
+++ b/cli/commands/guard.mjs
@@ -141,6 +141,7 @@ import { validateTodoTracking } from '../validators/todo-tracking.mjs';
 import { validateSchemaSync } from '../validators/schema-sync.mjs';
 import { validateSpecKitIntegration } from '../validators/spec-kit.mjs';
 import { validateCanonicalSync } from '../validators/canonical-sync.mjs';
+import { validateSurfaceSync } from '../validators/surface-sync.mjs';
 
 /**
  * Internal guard — returns structured data, no console output, no process.exit.
@@ -215,6 +216,7 @@ export function runGuardInternal(projectDir, config) {
     { key: 'specKit', name: 'Spec-Kit', fn: () => validateSpecKitIntegration(projectDir, config) },
     { key: 'crossReference', name: 'Cross-Reference', fn: () => validateCrossReferences(projectDir, config) },
     { key: 'generatedStaleness', name: 'Generated-Staleness', fn: () => validateGeneratedStaleness(projectDir, config) },
+    { key: 'surfaceSync', name: 'Surface-Sync', fn: () => validateSurfaceSync(projectDir, config) },
     // Metrics-Consistency runs post-loop (needs guard results)
   ];
 

--- a/cli/commands/memory.mjs
+++ b/cli/commands/memory.mjs
@@ -84,8 +84,18 @@ export function runMemory(projectDir, config, flags) {
   // ── Text output ──
   console.log(`${c.bold}🧠 DocGuard Memory${c.reset} ${c.dim}— ${config.projectName}${c.reset}\n`);
 
+  // Label is `Claim match rate` (not `Accuracy`) to disambiguate from the
+  // score-level `Accuracy` metric in `docguard score`, which is a weighted
+  // average across the entire accuracy axis (apiSurface, environment, drift,
+  // metadata-sync, etc.) and uses a different denominator. Both numbers are
+  // legitimate, but the same word was pointing at two different calculations
+  // — users saw "Accuracy 0%" here and "Accuracy 93%" in `score` on the same
+  // project and reasonably read it as a contradiction. This metric is the
+  // strict per-claim ratio (matched claims / total checked claims, restricted
+  // to domains that actually have any claims).
   const accColor = overallAccuracy >= 90 ? c.green : overallAccuracy >= 70 ? c.yellow : c.red;
-  console.log(`  ${c.bold}Accuracy:${c.reset} ${accColor}${overallAccuracy}%${c.reset} ${c.dim}(${totalMatched}/${totalChecks} doc claims match code)${c.reset}\n`);
+  console.log(`  ${c.bold}Claim match rate:${c.reset} ${accColor}${overallAccuracy}%${c.reset} ${c.dim}(${totalMatched}/${totalChecks} doc claims match code)${c.reset}`);
+  console.log(`  ${c.dim}   ↳ See ${c.cyan}docguard score${c.dim} for the weighted accuracy axis across all domains.${c.reset}\n`);
 
   if (totalChecks === 0) {
     console.log(`  ${c.dim}No applicable domains found — add canonical docs (API-REFERENCE.md, DATA-MODEL.md, ENVIRONMENT.md) and rerun.${c.reset}`);

--- a/cli/commands/upgrade.mjs
+++ b/cli/commands/upgrade.mjs
@@ -274,6 +274,18 @@ export async function runUpgrade(projectDir, _config, flags) {
         process.exit(1);
       }
       console.log(`  ${c.green}✓ CLI upgraded.${c.reset}`);
+      // Validator-count drift: a CLI upgrade often adds or removes validators,
+      // which changes the "N validators" / "N checks" totals that Metrics-
+      // Consistency scans for in markdown. Without a clear nudge here, a
+      // previously-green project goes red on the very next `docguard guard`
+      // for a reason the user did not cause. The fix is mechanical (replace
+      // hardcoded counts via fix --write) but the user has to know to run it.
+      // We don't auto-run fix --write from this process — the just-installed
+      // binary has the new validator list, but THIS process is still the OLD
+      // binary, so running fix here would use stale counts.
+      console.log(`  ${c.yellow}ℹ  Validator/check totals may have shifted with this upgrade.${c.reset}`);
+      console.log(`     Run ${c.cyan}docguard fix --write${c.reset} ${c.dim}to refresh hardcoded counts in your docs${c.reset}`);
+      console.log(`     ${c.dim}(picks up the new totals from the just-installed CLI).${c.reset}`);
     }
 
     if (schemaBehind && projectSchema) {

--- a/cli/docguard.mjs
+++ b/cli/docguard.mjs
@@ -230,7 +230,7 @@ const _KNOWN_VALIDATORS = [
   'security', 'architecture', 'freshness', 'traceability', 'docsDiff',
   'apiSurface', 'metadataSync', 'docsCoverage', 'docQuality', 'todoTracking',
   'schemaSync', 'specKit', 'crossReference', 'generatedStaleness',
-  'metricsConsistency',
+  'canonicalSync', 'surfaceSync', 'metricsConsistency',
 ];
 
 function _kebabToCamel(k) {

--- a/cli/scanners/routes.mjs
+++ b/cli/scanners/routes.mjs
@@ -108,8 +108,14 @@ function scanNextJsRoutes(dir) {
       const content = readFileSafe(filePath);
       if (!content) return;
 
-      // Path from directory structure
-      const relDir = relative(resolve(dir, appDir.split('/')[0]), dirname(filePath));
+      // Path from directory structure. The HTTP base in Next.js App Router is
+      // `/api/...` — Next strips everything up to and including the `app/`
+      // segment. Compute the relative path from the directory ABOVE `api/`
+      // so both `app/api` (no src layout) and `src/app/api` (src layout)
+      // produce `/api/<segments>`. Previously `appDir.split('/')[0]` stripped
+      // only `src/` for the src layout, leaking `app/` into the emitted path.
+      const apiBase = appDir.slice(0, appDir.lastIndexOf('/'));
+      const relDir = relative(resolve(dir, apiBase), dirname(filePath));
       const apiPath = '/' + relDir
         .replace(/\\/g, '/')
         .replace(/\[\.\.\.(\w+)\]/g, ':$1*')  // Catch-all [...slug]

--- a/cli/shared-source.mjs
+++ b/cli/shared-source.mjs
@@ -217,6 +217,15 @@ export function grepEnvUsage(projectDir, config = {}) {
     new RegExp(`process\\.env\\.${NAME}`, 'g'),
     new RegExp(`process\\.env\\[\\s*['"]${NAME}['"]\\s*\\]`, 'g'),
     new RegExp(`import\\.meta\\.env\\.${NAME}`, 'g'),
+    // Python: `os.environ["X"]`, `os.environ.get("X")`, `os.getenv("X")`. The
+    // `explain` command and ENVIRONMENT.md templates have always told users
+    // these forms are scanned, but the implementation only handled JS. On a
+    // Python project this caused every documented env var to be reported as
+    // "in docs, not in code" — a silent 0% accuracy. Patterns cover bracket
+    // access, .get(), and the standalone os.getenv() function.
+    new RegExp(`os\\.environ\\[\\s*['"]${NAME}['"]\\s*\\]`, 'g'),
+    new RegExp(`os\\.environ\\.get\\s*\\(\\s*['"]${NAME}['"]`, 'g'),
+    new RegExp(`os\\.getenv\\s*\\(\\s*['"]${NAME}['"]`, 'g'),
   ];
   // Vite injects these at build time; they are not user-set env vars.
   const VITE_INTRINSICS = new Set(['DEV', 'PROD', 'MODE', 'BASE_URL', 'SSR']);

--- a/cli/validators/docs-diff.mjs
+++ b/cli/validators/docs-diff.mjs
@@ -42,6 +42,17 @@ export function validateDocsDiff(projectDir, config) {
     diffTests(projectDir, config),
   ];
 
+  // Limit how many offending names are inlined in a single warning — keeps
+  // the line readable on terminals while still naming the specific files so
+  // the warning is actually actionable. Without these names the user gets a
+  // bare count ("1 documented but not found in code") with no path to debug.
+  const MAX_INLINE = 5;
+  const fmtList = (arr) => {
+    const shown = arr.slice(0, MAX_INLINE).map(v => `\`${v}\``).join(', ');
+    const extra = arr.length - MAX_INLINE;
+    return extra > 0 ? `${shown} (+${extra} more)` : shown;
+  };
+
   for (const result of checks) {
     if (!result) continue;
 
@@ -53,9 +64,13 @@ export function validateDocsDiff(projectDir, config) {
       passed++;
     } else {
       const parts = [];
-      if (undocumented > 0) parts.push(`${undocumented} in code but not documented`);
-      if (stale > 0) parts.push(`${stale} documented but not found in code`);
-      warnings.push(`${result.title} drift: ${parts.join(', ')}`);
+      if (undocumented > 0) {
+        parts.push(`${undocumented} in code but not documented: ${fmtList(result.onlyInCode)}`);
+      }
+      if (stale > 0) {
+        parts.push(`${stale} documented but not found in code: ${fmtList(result.onlyInDocs)}`);
+      }
+      warnings.push(`${result.title} drift: ${parts.join('; ')}`);
     }
   }
 

--- a/cli/validators/environment.mjs
+++ b/cli/validators/environment.mjs
@@ -64,6 +64,19 @@ export function validateEnvironment(projectDir, config) {
       if (SYSTEM.has(m[1])) continue; // v0.16-P4: prose mentions of system vars are not docs
       documented.add(m[1]);
     }
+    // Also extract markdown table rows where the first column is a bare env
+    // var name (no backticks). Real-world ENVIRONMENT.md docs frequently use
+    // pipe tables with un-backticked names — the backtick-only regex above
+    // silently misses every suffixed variant (DYNAMODB_TABLE_JOBS,
+    // DYNAMODB_TABLE_SOURCES, …) and they get reported as undocumented.
+    // Match `| VAR_NAME |` anywhere on the line; require the row to also
+    // contain a second `|` (real table row), not a stray pipe in prose.
+    const tableRe = /^\s*\|\s*([A-Z][A-Z0-9_]*[A-Z0-9])\s*\|/gm;
+    while ((m = tableRe.exec(content)) !== null) {
+      if (m[1].length < 3) continue;
+      if (SYSTEM.has(m[1])) continue;
+      documented.add(m[1]);
+    }
     for (const envFile of ['.env.example', '.env.template']) {
       const p = resolve(projectDir, envFile);
       if (!existsSync(p)) continue;

--- a/cli/validators/freshness.mjs
+++ b/cli/validators/freshness.mjs
@@ -6,7 +6,7 @@
  * but the code has already been implemented and committed.
  */
 
-import { existsSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { resolve, join, extname } from 'node:path';
 import { execSync, execFileSync } from 'node:child_process';
 
@@ -33,6 +33,26 @@ const IGNORE_DIRS = new Set([
   'coverage', '.cache', '__pycache__', '.venv', 'vendor',
   'templates', 'configs', 'Research',
 ]);
+
+/**
+ * Read the `<!-- docguard:last-reviewed YYYY-MM-DD -->` header from a doc file.
+ * Returns the parsed Date when present, null otherwise (file missing, header
+ * absent, or date unparseable). The header is the authoritative review date
+ * — it represents an explicit human review action that `git log` cannot see
+ * (e.g., the reviewer read the file, confirmed it still matches reality, and
+ * stamped the header without touching content, so there is no commit to find).
+ */
+function readLastReviewedDate(absPath) {
+  try {
+    const content = readFileSync(absPath, 'utf-8');
+    const m = content.match(/<!--\s*docguard:last-reviewed\s+(\d{4}-\d{2}-\d{2})\s*-->/);
+    if (!m) return null;
+    const d = new Date(m[1] + 'T00:00:00Z');
+    return isNaN(d.getTime()) ? null : d;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Get the last git commit date for a file.
@@ -170,7 +190,15 @@ export function validateFreshness(dir, config) {
     const docPath = resolve(dir, docFile);
     if (!existsSync(docPath)) continue;
 
-    const docDate = getLastGitDate(docFile, dir);
+    // Prefer the explicit `<!-- docguard:last-reviewed YYYY-MM-DD -->` header
+    // over the git commit date. A reviewer who reads a doc and stamps the
+    // header without changing content has signaled "I confirmed this is still
+    // current" — git log cannot see that signal, so it would falsely flag the
+    // doc as stale despite the explicit review. Fall back to git log only when
+    // the header is absent. Symmetric with the ALCOA+ "review metadata present"
+    // check in score.mjs, which reads the same header.
+    const reviewedDate = readLastReviewedDate(docPath);
+    const docDate = reviewedDate || getLastGitDate(docFile, dir);
     if (!docDate) {
       // File exists but isn't tracked in git yet
       results.push({
@@ -212,7 +240,9 @@ export function validateFreshness(dir, config) {
   // ── 2. Check CHANGELOG.md was updated in the last 5 code commits ──
   const changelogPath = resolve(dir, config.requiredFiles?.changelog || 'CHANGELOG.md');
   if (existsSync(changelogPath)) {
-    const changelogDate = getLastGitDate(config.requiredFiles?.changelog || 'CHANGELOG.md', dir);
+    const changelogDate =
+      readLastReviewedDate(changelogPath) ||
+      getLastGitDate(config.requiredFiles?.changelog || 'CHANGELOG.md', dir);
     if (changelogDate && latestCodeDate) {
       const daysDiff = Math.floor((latestCodeDate - changelogDate) / (1000 * 60 * 60 * 24));
       if (daysDiff > 7) {

--- a/cli/validators/surface-sync.mjs
+++ b/cli/validators/surface-sync.mjs
@@ -1,0 +1,365 @@
+/**
+ * Surface-Sync Validator — item-level drift detection for enumerable surfaces.
+ *
+ * Complements canonical-sync (which checks NUMERIC count claims) by checking
+ * that each individual ITEM in a code-derived list is actually documented as
+ * a list entry in the target markdown file(s). Catches the "demo command
+ * exists in code, the count matches, but it's missing from the README's
+ * command table" class of drift — invisible to count-based checks.
+ *
+ * Why this exists: canonical-sync was passing 3/3 on a docguard repo whose
+ * README's command table omitted `demo` entirely. The count matched ("14
+ * commands" = 14 user-facing commands in --help) but the table only listed
+ * 13 of them. Without an item-level check, a doc can be silently wrong while
+ * every count-based validator celebrates. That's exactly the credibility hit
+ * the user reported.
+ *
+ * How it works: for each configured surface (commands, validators, slash
+ * commands, templates, anything enumerable), we:
+ *   1. Discover the code-truth set from a glob pattern + basename extractor
+ *   2. For each target doc, parse all markdown tables and bullet lists,
+ *      collecting backticked tokens that look like identifiers from the
+ *      FIRST column / item position only (not arbitrary prose mentions)
+ *   3. Diff the two sets and warn on items present in code but absent from
+ *      the doc, OR present in the doc but missing from code (likely
+ *      removed / renamed)
+ *
+ * Scoped to list contexts on purpose: scanning every backtick would produce
+ * false positives every time someone wrote `--verbose` or `process.env.X`
+ * in prose. A table row or bullet item is a deliberate inventory signal —
+ * docguard treats those as the doc's authoritative list, ignores the rest.
+ *
+ * Default: N/A. The validator is OFF unless the project's .docguard.json
+ * declares at least one surface under `validators.surfaceSync.surfaces`.
+ * This keeps the upgrade path safe for projects that don't opt in.
+ *
+ * Config shape (in .docguard.json):
+ *   {
+ *     "validators": { "surfaceSync": true },
+ *     "surfaceSync": {
+ *       "surfaces": [
+ *         {
+ *           "name": "commands",
+ *           "glob": "cli/commands/*.mjs",
+ *           "extract": "basename-no-ext",  // "basename" or "basename-no-ext"
+ *           "ignore": ["setup", "impact"],  // known aliases / non-public items
+ *           "docs": ["README.md"]
+ *         }
+ *       ]
+ *     }
+ *   }
+ *
+ * Severity: MEDIUM. Wrong-list drift is real but rarely a build-breaker —
+ * users can still read the doc and discover the missing surface via --help.
+ * Demoting to LOW makes drift invisible; promoting to HIGH would conflict
+ * with the existing reality that many projects ship slightly-stale READMEs.
+ *
+ * Zero NPM runtime dependencies — pure Node.js built-ins only.
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join, basename, extname, relative, dirname } from 'node:path';
+
+/**
+ * Expand a simple glob (only supports `*` at the leaf segment level —
+ * sufficient for `cli/commands/*.mjs`, `templates/*.md.template`, etc.).
+ * Recursive `**` is NOT supported by design — surface lists live in
+ * known shallow directories; deep recursion would be a configuration
+ * smell, not a feature.
+ */
+function expandGlob(projectDir, glob) {
+  const slash = glob.lastIndexOf('/');
+  const dir = slash >= 0 ? glob.slice(0, slash) : '.';
+  const pattern = slash >= 0 ? glob.slice(slash + 1) : glob;
+  const absDir = resolve(projectDir, dir);
+  if (!existsSync(absDir)) return [];
+
+  // Convert glob to regex: escape regex specials, then `*` → `.*`
+  const rx = new RegExp('^' + pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*') + '$');
+
+  try {
+    return readdirSync(absDir)
+      .filter(name => rx.test(name))
+      .map(name => join(absDir, name))
+      .filter(full => {
+        try { return statSync(full).isFile(); } catch { return false; }
+      });
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Extract the surface name from a file path according to the configured rule.
+ * `basename`        → keep the full filename: `guard.mjs`
+ * `basename-no-ext` → strip the single trailing extension: `guard`
+ *
+ * `basename-no-ext` strips ONLY the last extension on purpose. For files like
+ * `ARCHITECTURE.md.template`, `basename-no-ext` returns `ARCHITECTURE.md` —
+ * which is the canonical doc name the template generates. If the user wants
+ * the bare `ARCHITECTURE`, they can use a custom extractor (not yet supported).
+ */
+function applyExtractor(filePath, extractor) {
+  const base = basename(filePath);
+  if (extractor === 'basename') return base;
+  if (extractor === 'basename-no-ext') {
+    const ext = extname(base);
+    return ext ? base.slice(0, -ext.length) : base;
+  }
+  // Unknown extractor → fall back to bare basename. Don't throw — a future
+  // CLI version might introduce more extractors, and we want old configs to
+  // degrade gracefully rather than crash a guard run.
+  return base;
+}
+
+/**
+ * Slice a markdown document down to a single section, identified by a heading
+ * substring match (case-insensitive). The slice runs from that heading to the
+ * next heading of equal or higher level (so a `##` section ends at the next
+ * `##` or `#`, but `###` subsections are included).
+ *
+ * Returns the original `content` if `heading` is falsy. Returns an empty string
+ * if the heading isn't found — callers treat that as "section absent, no
+ * documented tokens here," which surfaces as a "missing-from-doc" warning for
+ * every code item (correctly: the section the user said to scope to does not
+ * exist in this doc).
+ */
+function sliceSection(content, heading) {
+  if (!heading) return content;
+  const lines = content.split('\n');
+  const needle = String(heading).toLowerCase().replace(/^#+\s*/, '').trim();
+  if (!needle) return content;
+
+  // Find the start: any heading line whose text (after stripping `#`s) contains
+  // the configured heading. Substring match keeps the config tolerant of
+  // emoji prefixes and trailing decorations in the actual document.
+  let startIdx = -1;
+  let startLevel = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^(#{1,6})\s+(.+?)\s*$/);
+    if (!m) continue;
+    const headingText = m[2].toLowerCase();
+    if (headingText.includes(needle)) {
+      startIdx = i;
+      startLevel = m[1].length;
+      break;
+    }
+  }
+  if (startIdx === -1) return '';
+
+  // Find the end: next heading of <= startLevel depth.
+  let endIdx = lines.length;
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    const m = lines[i].match(/^(#{1,6})\s+/);
+    if (m && m[1].length <= startLevel) {
+      endIdx = i;
+      break;
+    }
+  }
+  return lines.slice(startIdx, endIdx).join('\n');
+}
+
+/**
+ * Parse a markdown file (or a slice of one) and return the set of tokens
+ * found in "list contexts" — table rows (first column) and bullet items.
+ * Backtick-wrapped only. This deliberately ignores backticks in prose,
+ * code blocks, and headings.
+ *
+ * Code blocks (```...```) are stripped first so that a fenced shell example
+ * like `npx docguard-cli demo` cannot inflate the documented set with the
+ * `demo` token. Tables and bullets remain the only authoritative inventory.
+ */
+function extractDocumentedTokens(content) {
+  const tokens = new Set();
+  // Strip fenced code blocks — shell examples, json snippets, mermaid blocks,
+  // and any inline reference inside them is NOT a list entry.
+  const stripped = content.replace(/```[\s\S]*?```/g, '');
+
+  // Normalize a captured token. Strips a leading `docguard ` or `/` (common
+  // doc conventions for command tables and slash-command lists), reduces
+  // multi-word forms to the first token, and lower-cases — downstream
+  // comparison is case-insensitive so README's `**API-Surface**` matches
+  // code-truth `api-surface`.
+  const normalize = (raw) => {
+    if (!raw) return '';
+    const cleaned = String(raw).trim()
+      .replace(/^docguard\s+/i, '')
+      .replace(/^\//, '');
+    const firstToken = cleaned.split(/\s+/)[0];
+    return firstToken.toLowerCase();
+  };
+
+  // Pattern A: backticked token in a list context.
+  //   - Start of a table row:                 `| `name` | … |`
+  //   - Numbered-cell table row:              `| 1 | `name` | … |`
+  //   - Bullet list item:                     `- `name` …`
+  // Restricting to these contexts keeps prose backticks out of the
+  // documented set; a backticked `--verbose` mid-paragraph is not a list
+  // entry and must not inflate the set.
+  const backtickListRe =
+    /(?:^\s*\|\s*(?:\d+\s*\|\s*)?|^\s*[-*+]\s+)`([^`\n]+)`/gim;
+  let m;
+  while ((m = backtickListRe.exec(stripped)) !== null) {
+    const t = normalize(m[1]);
+    if (t) tokens.add(t);
+  }
+
+  // Pattern B: bolded token in a table row. Matches the validators-style
+  // tables that use `| N | **Name** | description |` — backticks alone
+  // miss every entry in those tables. Restricted to lines starting with
+  // `|` so prose-level **bold** is not pulled in.
+  const boldRowRe = /^\s*\|.*?\*\*([^*\n]+)\*\*/gim;
+  while ((m = boldRowRe.exec(stripped)) !== null) {
+    const t = normalize(m[1]);
+    if (t) tokens.add(t);
+  }
+
+  return tokens;
+}
+
+/**
+ * Validate surface drift for a single surface against its target docs.
+ * Returns warnings, fixes, passed count, and total count.
+ */
+function checkSurface(projectDir, surface) {
+  const out = { warnings: [], fixes: [], passed: 0, total: 0 };
+  const name = surface.name || 'unnamed';
+  const extractor = surface.extract || 'basename-no-ext';
+  const ignore = new Set(surface.ignore || []);
+  const docs = Array.isArray(surface.docs) && surface.docs.length > 0
+    ? surface.docs
+    : ['README.md'];
+
+  // Discover code-truth set from glob.
+  if (!surface.glob || typeof surface.glob !== 'string') {
+    out.warnings.push(
+      `surfaceSync: surface "${name}" has no \`glob\` — skipping. Add a glob like "cli/commands/*.mjs".`
+    );
+    return out;
+  }
+  const files = expandGlob(projectDir, surface.glob);
+  // Lower-case code-truth to keep comparison case-insensitive — README
+  // commonly uses display-cased identifiers (`**API-Surface**`, `Freshness`)
+  // while file basenames are lowercase (`api-surface.mjs`). The `ignore`
+  // list is matched against the case-folded form, so users can write
+  // either `["Setup"]` or `["setup"]` and it works.
+  const ignoreLower = new Set([...ignore].map(s => String(s).toLowerCase()));
+  const codeTruth = new Set(
+    files
+      .map(f => applyExtractor(f, extractor).toLowerCase())
+      .filter(token => !ignoreLower.has(token))
+  );
+  if (codeTruth.size === 0) {
+    // No items discovered — surface is N/A for this project. Don't warn
+    // (the user has explicitly enabled the surface, but the glob found
+    // nothing — maybe they renamed a directory; surface up the info but
+    // do NOT escalate into a check failure).
+    return out;
+  }
+
+  // For each target doc, compute documented set and diff.
+  for (const docRel of docs) {
+    const docPath = resolve(projectDir, docRel);
+    if (!existsSync(docPath)) {
+      // Doc doesn't exist — silently skip; another validator (structure)
+      // covers missing-doc cases.
+      continue;
+    }
+
+    let content;
+    try {
+      content = readFileSync(docPath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    // Optional section scope: restrict scanning to a single heading's body.
+    // Without this, every backticked first-column token in the doc is
+    // pooled into one "documented" set — and a commands surface ends up
+    // matching against the validators table too, producing cross-table
+    // false positives. Section-scoping is the user's per-surface override
+    // when one doc lists multiple surfaces.
+    const scope = surface.section
+      ? sliceSection(content, surface.section)
+      : content;
+
+    const documented = extractDocumentedTokens(scope);
+    out.total++;
+
+    const missingFromDoc = [...codeTruth].filter(t => !documented.has(t));
+    // missingFromCode tells you about items the doc lists that don't exist
+    // in code — usually removed or renamed surfaces. Filter through `ignore`
+    // too so deprecation aliases listed in the doc don't fire warnings.
+    const missingFromCode = [...documented]
+      .filter(t => !codeTruth.has(t) && !ignoreLower.has(t))
+      // Only consider tokens that match the surface naming convention to
+      // avoid pulling in unrelated backticked items from a different table
+      // that happens to be in the same doc.
+      .filter(t => surfaceNameLooksValid(t));
+
+    if (missingFromDoc.length === 0 && missingFromCode.length === 0) {
+      out.passed++;
+      continue;
+    }
+
+    const parts = [];
+    if (missingFromDoc.length > 0) {
+      const shown = missingFromDoc.slice(0, 8).map(t => `\`${t}\``).join(', ');
+      const extra = missingFromDoc.length - 8;
+      const tail = extra > 0 ? ` (+${extra} more)` : '';
+      parts.push(`${missingFromDoc.length} in code but missing from ${docRel}: ${shown}${tail}`);
+    }
+    if (missingFromCode.length > 0) {
+      const shown = missingFromCode.slice(0, 8).map(t => `\`${t}\``).join(', ');
+      const extra = missingFromCode.length - 8;
+      const tail = extra > 0 ? ` (+${extra} more)` : '';
+      parts.push(`${missingFromCode.length} listed in ${docRel} but not found in code: ${shown}${tail}`);
+    }
+    out.warnings.push(`Surface "${name}" drift: ${parts.join('; ')}`);
+  }
+
+  return out;
+}
+
+/**
+ * Loose sanity filter for tokens before reporting them as "missing from code".
+ * Real surface names are short identifiers; if a regex catches something
+ * that looks like prose, drop it silently.
+ */
+function surfaceNameLooksValid(t) {
+  return typeof t === 'string'
+    && t.length >= 2
+    && t.length <= 64
+    && /^[a-z][a-z0-9_.-]*$/i.test(t);
+}
+
+/**
+ * Public entry point. Returns N/A when no surfaces are configured — by
+ * design, this validator is opt-in. Projects that don't declare surfaces
+ * see zero noise.
+ */
+export function validateSurfaceSync(projectDir, config) {
+  const surfaceCfg = (config && config.surfaceSync && Array.isArray(config.surfaceSync.surfaces))
+    ? config.surfaceSync.surfaces
+    : [];
+
+  const result = { errors: [], warnings: [], fixes: [], passed: 0, total: 0 };
+
+  if (surfaceCfg.length === 0) {
+    // No surfaces configured → N/A. The validator infrastructure surfaces
+    // this as "nothing to validate" rather than a fail.
+    return result;
+  }
+
+  for (const surface of surfaceCfg) {
+    const r = checkSurface(projectDir, surface);
+    result.warnings.push(...r.warnings);
+    result.fixes.push(...r.fixes);
+    result.passed += r.passed;
+    result.total += r.total;
+  }
+
+  return result;
+}

--- a/cli/validators/traceability.mjs
+++ b/cli/validators/traceability.mjs
@@ -64,6 +64,10 @@ const TRACE_MAP = {
   'API-REFERENCE.md': {
     sourcePatterns: [
       { label: 'Route handlers', glob: /(routes?|controllers?|handlers?)\// },
+      // Next.js App Router (and Pages Router) — `app/api/`, `src/app/api/`,
+      // `pages/api/`, `src/pages/api/`. Without this, a perfectly-populated
+      // Next.js API tree gets reported as "API-REFERENCE.md — unlinked doc".
+      { label: 'Next.js API routes', glob: /(^|\/)(app|pages)\/api\// },
       { label: 'OpenAPI spec', glob: /(openapi|swagger)\.(json|ya?ml)/ },
       { label: 'API middleware', glob: /middleware\// },
     ],
@@ -115,6 +119,15 @@ export function validateTraceability(projectDir, config) {
   const projectFiles = [];
   scanDir(projectDir, projectDir, projectFiles);
 
+  // Scan source files for `// @doc <filename>.md` annotations. An annotation
+  // is an explicit author signal that a source file documents (or is
+  // documented by) a canonical doc. It is the user-facing escape hatch when
+  // a project's directory layout doesn't match the built-in TRACE_MAP globs
+  // (e.g. a route file outside any `routes/` / `app/api/` tree). The
+  // annotation is also shown in templates and templates/commands docs, so
+  // users have been told it works — actually honoring it is the fix here.
+  const docAnnotations = scanDocAnnotations(projectFiles, projectDir);
+
   // ── Part 1: Source Traceability (existing) ──
   for (const [docName, traceInfo] of Object.entries(TRACE_MAP)) {
     // Skip docs not in the user's required list
@@ -126,6 +139,14 @@ export function validateTraceability(projectDir, config) {
 
     if (!docExists) {
       warnings.push(`${docName} — required but missing, no traceability possible`);
+      continue;
+    }
+
+    // Explicit `// @doc <docName>` annotation counts as a link regardless of
+    // whether the file path matches any built-in pattern. Checked first so
+    // path-pattern misses don't drown out explicit author intent.
+    if (docAnnotations.has(docName) && docAnnotations.get(docName).size > 0) {
+      passed++;
       continue;
     }
 
@@ -353,6 +374,50 @@ function getRequirementDocPaths(projectDir, config) {
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Scan code files for `// @doc <name>.md` annotations. Returns a Map from
+ * canonical doc basename → Set of source file paths that annotate it.
+ *
+ * Annotation forms accepted:
+ *   - `// @doc API-REFERENCE.md`
+ *   - `// @doc docs-canonical/API-REFERENCE.md`  (basename is what matters)
+ *   - `/* @doc API-REFERENCE.md *​/`              (block comment, single line)
+ *   - `# @doc API-REFERENCE.md`                  (Python / Ruby comment style)
+ *
+ * Only the basename of the referenced doc is keyed; callers compare against
+ * the doc basename (e.g. `API-REFERENCE.md`). We cap how many files we open
+ * to keep this scan O(N) and stop reading the rest of a file after the
+ * first 4 KB — annotations belong at the top of a file by convention, and
+ * reading every byte of every source file just to find a header comment
+ * would balloon scan time on large monorepos.
+ */
+function scanDocAnnotations(projectFiles, projectDir) {
+  const map = new Map();
+  const annotationRe = /(?:\/\/|\/\*|#)\s*@doc\s+(\S+\.md)/g;
+  const CODE_EXT = new Set(['.js', '.mjs', '.cjs', '.ts', '.tsx', '.jsx', '.py', '.rb', '.go', '.rs', '.java']);
+  const HEAD_BYTES = 4096;
+
+  for (const relPath of projectFiles) {
+    const ext = extname(relPath);
+    if (!CODE_EXT.has(ext)) continue;
+    const full = resolve(projectDir, relPath);
+    let content;
+    try { content = readFileSync(full, 'utf-8'); } catch { continue; }
+    // Annotations live near the top of the file. Slicing avoids reading
+    // megabytes of bundled / minified output looking for a header comment.
+    const head = content.length > HEAD_BYTES ? content.slice(0, HEAD_BYTES) : content;
+    if (!head.includes('@doc')) continue;
+    annotationRe.lastIndex = 0;
+    let m;
+    while ((m = annotationRe.exec(head)) !== null) {
+      const docName = basename(m[1]);
+      if (!map.has(docName)) map.set(docName, new Set());
+      map.get(docName).add(relPath);
+    }
+  }
+  return map;
+}
 
 function scanDir(rootDir, dir, files) {
   let entries;

--- a/docs-canonical/CI-RECIPES.md
+++ b/docs-canonical/CI-RECIPES.md
@@ -12,7 +12,7 @@ tag (e.g. `@v0.12.0`) in production — `@main` is fine for tracking the bleedin
 
 ## Recipe 1 — Guard (mandatory CI gate)
 
-Runs all 23 validators. Read-only — never modifies your repo.
+Runs all 24 validators. Read-only — never modifies your repo.
 
 ```yaml
 name: DocGuard Guard
@@ -153,7 +153,7 @@ pre-commit:
 ```
 
 `--changed-only` ships in v0.12 and runs only Docs-Sync, Environment, and
-API-Surface against the staged files (instead of all 23 validators against
+API-Surface against the staged files (instead of all 24 validators against
 the whole repo). See Recipe 5 below.
 
 ## Recipe 5 — Pre-commit lite (changed files only)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -68,7 +68,7 @@ diagnose  →  AI reads prompts  →  AI fixes docs  →  guard verifies
 ## Verify
 
 ```bash
-npx docguard-cli guard        # Pass/fail check (23 validators)
+npx docguard-cli guard        # Pass/fail check (24 validators)
 npx docguard-cli score        # 0-100 maturity score
 ```
 

--- a/extensions/spec-kit-docguard/README.md
+++ b/extensions/spec-kit-docguard/README.md
@@ -4,7 +4,7 @@ Enterprise-grade Canonical-Driven Development (CDD) enforcement and **AI-readabl
 
 ## Features
 
-- **23 Validators** — Structure, Security, Doc Quality, Test-Spec, Drift-Comments, API-Surface, Freshness, Cross-Reference, and 13 more
+- **24 Validators** — Structure, Security, Doc Quality, Test-Spec, Drift-Comments, API-Surface, Freshness, Cross-Reference, and 13 more
 - **Language-agnostic** — JS/TS, Python, Rust, Go, Java/Kotlin, Ruby, PHP, C#. Polyglot/monorepo-aware.
 - **AI-powered Generate** — `generate --plan` builds the code-truth skeleton in `<!-- docguard:section -->` markers and emits a structured agent task manifest; the AI writes the prose.
 - **Always up to date** — `sync` surgically refreshes code-truth doc sections in place, **preserves human prose**, flags prose for agent review.

--- a/extensions/spec-kit-docguard/extension.yml
+++ b/extensions/spec-kit-docguard/extension.yml
@@ -3,7 +3,7 @@ schema_version: "1.0"
 extension:
   id: "docguard"
   name: "DocGuard — CDD Enforcement"
-  version: "0.21.1"
+  version: "0.22.0"
   description: "Canonical-Driven Development enforcement as a true spec-kit extension. LLM-first design with 19 automated validators, 4 AI behavior skills, spec-kit skill chaining, and workflow hooks. Zero NPM runtime dependencies."
   author: "Ricardo Accioly"
   repository: "https://github.com/raccioly/docguard"

--- a/extensions/spec-kit-docguard/skills/docguard-fix/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-fix/SKILL.md
@@ -6,10 +6,10 @@ description: AI-driven documentation repair with structured research workflow, t
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.21.1
+  version: 0.22.0
   source: extensions/spec-kit-docguard/skills/docguard-fix
 ---
-<!-- docguard:version: 0.21.1 -->
+<!-- docguard:version: 0.22.0 -->
 
 # DocGuard Fix Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-guard/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-guard/SKILL.md
@@ -7,10 +7,10 @@ description: Run DocGuard guard validation against Canonical-Driven Development 
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.21.1
+  version: 0.22.0
   source: extensions/spec-kit-docguard/skills/docguard-guard
 ---
-<!-- docguard:version: 0.21.1 -->
+<!-- docguard:version: 0.22.0 -->
 
 # DocGuard Guard Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-review/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-review/SKILL.md
@@ -6,10 +6,10 @@ description: Cross-document consistency analysis and quality assessment. Perform
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.21.1
+  version: 0.22.0
   source: extensions/spec-kit-docguard/skills/docguard-review
 ---
-<!-- docguard:version: 0.21.1 -->
+<!-- docguard:version: 0.22.0 -->
 
 # DocGuard Review Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-score/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-score/SKILL.md
@@ -6,10 +6,10 @@ description: CDD maturity assessment with category-aware improvement roadmap. Ru
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.21.1
+  version: 0.22.0
   source: extensions/spec-kit-docguard/skills/docguard-score
 ---
-<!-- docguard:version: 0.21.1 -->
+<!-- docguard:version: 0.22.0 -->
 
 # DocGuard Score Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-sync/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-sync/SKILL.md
@@ -4,7 +4,7 @@ description: Keep canonical documentation ALWAYS UP TO DATE. Refreshes code-trut
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.21.1
+  version: 0.22.0
   source: extensions/spec-kit-docguard/skills/docguard-sync
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docguard-cli",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "The enforcement tool for Canonical-Driven Development (CDD). Audit, generate, and guard your project documentation.",
   "type": "module",
   "bin": {

--- a/schemas/docguard-config.schema.json
+++ b/schemas/docguard-config.schema.json
@@ -102,6 +102,8 @@
         "specKit":            { "type": "boolean" },
         "crossReference":    { "type": "boolean" },
         "generatedStaleness":{ "type": "boolean" },
+        "canonicalSync":     { "type": "boolean" },
+        "surfaceSync":       { "type": "boolean" },
         "metricsConsistency":{ "type": "boolean" }
       },
       "additionalProperties": false
@@ -146,6 +148,30 @@
         "deepScan": {
           "type": "boolean",
           "description": "If true and the `understanding` CLI is on PATH, run its 31-metric deep analysis. Off by default."
+        }
+      },
+      "additionalProperties": true
+    },
+    "surfaceSync": {
+      "type": "object",
+      "description": "Surface-Sync validator: item-level drift between code-derived enumerables (commands, validators, templates) and the lists in target docs (README.md, AGENTS.md). Default: N/A unless `surfaces` is declared.",
+      "properties": {
+        "surfaces": {
+          "type": "array",
+          "description": "Enumerable surfaces to check. Each surface compares code-truth (from a glob) against documented list entries in target markdown files.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name":    { "type": "string", "description": "Human-readable surface name used in warnings (e.g. \"commands\")." },
+              "glob":    { "type": "string", "description": "Glob discovering the code-truth files (e.g. `cli/commands/*.mjs`). Only leaf `*` supported." },
+              "extract": { "type": "string", "enum": ["basename", "basename-no-ext"], "description": "How to derive the surface name from each file path." },
+              "ignore":  { "type": "array", "items": { "type": "string" }, "description": "Surface names to skip (e.g. known deprecation aliases)." },
+              "docs":    { "type": "array", "items": { "type": "string" }, "description": "Target markdown files to scan for documented list entries." },
+              "section": { "type": "string", "description": "Optional heading text to scope the scan (substring match, case-insensitive). Without it, the entire doc is scanned and tables for OTHER surfaces produce cross-table false positives. Use when one doc lists multiple surfaces." }
+            },
+            "required": ["name", "glob"],
+            "additionalProperties": false
+          }
         }
       },
       "additionalProperties": true

--- a/specs/004-v020-env-var-false-negative/spec.md
+++ b/specs/004-v020-env-var-false-negative/spec.md
@@ -1,0 +1,147 @@
+# Feature Specification: Fix Env-Var Detector False Negative & Accuracy Terminology
+
+**Feature Branch**: `004-v020-env-var-false-negative`  
+**Created**: 2026-05-26  
+**Status**: Draft  
+**Input**: Field test of DocGuard v0.20.0 on the canonical-spec-kit project itself (79/79 guard pass, 96/100 score). Two issues surfaced that prevent the score from reaching 100/100.
+
+---
+
+## Context
+
+DocGuard v0.20.0 was run on a live project with a documented env-var (`PYTEST_CURRENT_TEST`) that is accessed in code via `os.environ.get("X")`. The env-var detector reported it as "in docs but missing from code" — a false negative. Separately, the word "accuracy" appears in both `docguard memory` and `docguard score` but is computed against different denominators, creating confusion.
+
+These are two independent defects discovered in the same session.
+
+---
+
+## Bug 1: Env-Var Detector Has Zero Python Support
+
+### Evidence
+
+`PYTEST_CURRENT_TEST` is present in `ENVIRONMENT.md` **and** in production code:
+
+```python
+# src/quick_recon/run_history.py:54
+if os.environ.get("PYTEST_CURRENT_TEST"):
+```
+
+`docguard memory --diff` output:
+
+```
+PYTEST_CURRENT_TEST: in docs, not found in code  ← FALSE NEGATIVE
+```
+
+### Root Cause (CORRECTED after code audit)
+
+The original bug report assumed the Python env-var scanner existed and just
+missed the `.get()` form. Source code audit reveals a more fundamental
+problem: **the env-var scanner has no Python support at all.**
+
+`cli/shared-source.mjs` `grepEnvUsage()` regex list (before fix):
+
+```javascript
+const patterns = [
+  new RegExp(`process\\.env\\.${NAME}`, 'g'),
+  new RegExp(`process\\.env\\[\\s*['"]${NAME}['"]\\s*\\]`, 'g'),
+  new RegExp(`import\\.meta\\.env\\.${NAME}`, 'g'),
+];
+```
+
+All three are JavaScript. `.py` files are walked (they're in
+`CODE_EXTENSIONS`), but none of the patterns can match Python access forms —
+so EVERY documented Python env var is reported as "in docs, not in code",
+not just the `.get()` ones. The user reported `PYTEST_CURRENT_TEST` because
+it stood out, but the bug also hits `os.environ["X"]`, `os.environ.get("X")`,
+and `os.getenv("X")` identically.
+
+The `cli/commands/explain.mjs` text claims `os.environ` is scanned for
+Python — aspirational documentation, not actual behavior.
+
+### Fix
+
+Add three patterns to the regex list, one per common Python access form:
+
+```javascript
+new RegExp(`os\\.environ\\[\\s*['"]${NAME}['"]\\s*\\]`, 'g'),
+new RegExp(`os\\.environ\\.get\\s*\\(\\s*['"]${NAME}['"]`, 'g'),
+new RegExp(`os\\.getenv\\s*\\(\\s*['"]${NAME}['"]`, 'g'),
+```
+
+Applied additively — no JS pattern changes, no schema or config changes.
+
+### Acceptance Criteria
+
+1. A file containing `os.environ.get("PYTEST_CURRENT_TEST")` causes `PYTEST_CURRENT_TEST` to be counted as **present in code**.
+2. A file containing `os.environ["DATABASE_URL"]` continues to work as before.
+3. Both forms in the same file are correctly deduplicated (var counted once, not twice).
+4. `docguard memory --diff` no longer reports a false negative for this variable after fix.
+
+---
+
+## Bug 2: "Accuracy" Points at Two Different Denominators
+
+### Evidence
+
+Same project, same run:
+
+| Command | Output |
+|---|---|
+| `docguard memory` (env-var domain) | `Accuracy: 0% (0/1 doc claims match code)` |
+| `docguard score` | `Memory accuracy: 93%` |
+
+Same word, same project, wildly different numbers.
+
+### Root Cause
+
+- `docguard memory` computes accuracy over **domains with ≥1 claim** only.
+- `docguard score` computes accuracy over **all domains** (domains with no claims count as pass).
+
+Neither calculation is wrong. The labelling is the problem.
+
+### Fix
+
+**Option A (preferred)**: Rename `memory` per-domain metric to `Claim match rate` to visually distinguish it from the score-level `Accuracy`.
+
+**Option B**: Add a denominator note inline:
+```
+Accuracy: 0% (0/1 claimed vars found in code — full-project accuracy: 93%)
+```
+
+### Acceptance Criteria
+
+1. Running `docguard memory` and `docguard score` on the same project does not surface two "Accuracy" numbers with different values and no explanation.
+2. The relationship between the per-domain metric and the score-level metric is visible without consulting the docs.
+
+---
+
+## Impact
+
+| Issue | Current score impact | After fix |
+|---|---|---|
+| Env-var false negative | 96/100 (loses points for "code missing claim") | 97–100/100 |
+| Accuracy label confusion | No score impact; UX impact | No change |
+
+---
+
+## Out of Scope
+
+- No changes to the scoring algorithm.
+- No changes to `ENVIRONMENT.md` template or the env-var *list* (the variable is correctly documented).
+- No new validators.
+
+---
+
+## Notes
+
+This spec was generated from v0.20.0 field test results. The env-var false negative is a **confirmed regression** path — the variable is genuinely present in code and the detector simply does not match the `.get()` form. No ambiguity about whether this is a real bug.
+
+The accuracy-label issue was surfaced because v0.20.0 introduced `memory --diff`, which now makes the per-domain breakdown visible for the first time. Pre-v0.20.0, the confusion was latent.
+
+---
+
+*Field test date: 2026-05-26 — canonical-spec-kit @ v0.20.0 (79/79 guard pass)*
+
+---
+
+**See also**: [`specs/005-hugocross-next-bugs/spec.md`](../005-hugocross-next-bugs/spec.md) — 6 additional bugs from the same v0.20.0 field test cycle on a Next.js project.

--- a/specs/005-hugocross-next-bugs/spec.md
+++ b/specs/005-hugocross-next-bugs/spec.md
@@ -1,0 +1,365 @@
+# Feature Specification: Fix 6 Confirmed Bugs from HugoCross Next.js Field Test
+
+**Feature Branch**: `005-hugocross-next-bugs`  
+**Created**: 2026-05-26  
+**Status**: Draft  
+**Input**: Full review session running DocGuard v0.20.0 on a production Next.js 15 App Router project (hugocross_revamp). 6 bugs confirmed — all evidence-backed, none speculative.
+
+---
+
+## Context
+
+HugoCross is a stablecoin content engine built on Next.js 15 App Router with TypeScript, Tailwind, and DynamoDB. Running `docguard guard` produced a cascade of false positives and unactionable warnings. Root causes were traced to source code. Priority order per the reporter: Bug 1 > Bug 2 > Bug 4 > Bug 3 > Bug 6 > Bug 5. Bug 1 alone accounts for ~113 false-positive API-Surface warnings.
+
+---
+
+## Bug 1 (P0): API-Surface scanner emits wrong HTTP path for Next.js App Router
+
+**Severity**: 🔴 Critical — makes the API-Surface validator completely unusable for Next.js App Router codebases  
+**File**: `cli/scanners/routes.mjs:112`
+
+### Root Cause (confirmed in code)
+
+```javascript
+// routes.mjs, scanNextJsRoutes()
+const appDirs = ['app/api', 'src/app/api'];
+for (const appDir of appDirs) {
+  ...
+  const relDir = relative(resolve(dir, appDir.split('/')[0]), dirname(filePath));
+  const apiPath = '/' + relDir...
+```
+
+For `appDir = 'src/app/api'`:
+- `appDir.split('/')[0]` → `'src'` (wrong — strips only `src/`)
+- `relative(<project>/src, <project>/src/app/api/health/)` → `app/api/health`
+- Emitted path: `GET /app/api/health` (wrong)
+- Correct path: `GET /api/health`
+
+For `appDir = 'app/api'` (no `src/`):
+- `appDir.split('/')[0]` → `'app'` (accidentally correct)
+- `relative(<project>/app, <project>/app/api/health/)` → `api/health`
+- Emitted path: `GET /api/health` ✅
+
+### Effect
+
+Every route under `src/app/api/` produces two simultaneous warnings:
+1. "Documented endpoint not found in code: GET /api/X" (the real path)
+2. "Undocumented endpoint in code: GET /app/api/X" (the phantom path)
+
+Same file, two warnings, both wrong. All 113 API-Surface checks in the test project were false positives from this one line.
+
+### Fix
+
+```diff
+- const relDir = relative(resolve(dir, appDir.split('/')[0]), dirname(filePath));
++ const apiBase = appDir.slice(0, appDir.lastIndexOf('/'));   // 'src/app' or 'app'
++ const relDir = relative(resolve(dir, apiBase), dirname(filePath));
+```
+
+`appDir.lastIndexOf('/')` correctly identifies the parent of `api/` regardless of depth:
+- `'app/api'` → `apiBase = 'app'` (unchanged from current behavior for non-src layout)
+- `'src/app/api'` → `apiBase = 'src/app'` (fixes the bug)
+
+### Acceptance Criteria
+
+1. A Next.js project with routes under `src/app/api/health/route.ts` emits `GET /api/health` (not `GET /app/api/health`).
+2. A Next.js project with routes under `app/api/health/route.ts` still emits `GET /api/health` (no regression).
+3. Running `docguard guard` on a project with a matching OpenAPI spec produces 0 API-Surface false positives for Next.js App Router routes.
+
+---
+
+## Bug 2 (P1): Freshness check ignores `<!-- docguard:last-reviewed -->` header
+
+**Severity**: 🟠 High — documented feature has zero effect; misleading UX  
+**File**: `cli/validators/freshness.mjs` (entire function)
+
+### Root Cause (confirmed in code)
+
+`validateFreshness()` never reads file content. It calls only `getLastGitDate()` which runs `git log --` on the file. The `<!-- docguard:last-reviewed YYYY-MM-DD -->` header is:
+
+- Injected by `docguard generate` into every generated doc template (6 occurrences in `generate.mjs`)
+- Listed in every template file under `templates/`
+- Checked by `score.mjs:291` for ALCOA+ compliance
+- Suggested as the fix action in the freshness warning text itself (`score.mjs:336`)
+
+But `freshness.mjs` never reads it. Updating the header has zero effect on the freshness check.
+
+### Effect
+
+- Uncommitted doc updates keep firing freshness warnings regardless of the header value
+- The fix suggestion ("add `<!-- docguard:last-reviewed YYYY-MM-DD -->`") is actively misleading
+- The ALCOA+ "review metadata present" check passes while the freshness check fires simultaneously — two checks disagree on the same file
+
+### Fix
+
+Add a `readLastReviewedDate(docPath)` helper that parses the header:
+
+```javascript
+function readLastReviewedDate(docPath) {
+  try {
+    const content = readFileSync(docPath, 'utf-8');
+    const m = content.match(/<!--\s*docguard:last-reviewed\s+(\d{4}-\d{2}-\d{2})\s*-->/);
+    return m ? new Date(m[1]) : null;
+  } catch {
+    return null;
+  }
+}
+```
+
+In `validateFreshness()`, prefer the header over `git log`:
+
+```javascript
+const headerDate = readLastReviewedDate(docPath);
+const docDate = headerDate ?? getLastGitDate(docFile, dir);
+```
+
+The header is the authoritative review date; git log is the fallback proxy.
+
+### Acceptance Criteria
+
+1. A doc file with `<!-- docguard:last-reviewed 2026-05-26 -->` set to today's date does NOT fire a freshness warning, even if the git commit predates the threshold.
+2. A doc file with no `docguard:last-reviewed` header still uses `git log` as before (no regression for existing projects).
+3. A doc file with a stale `<!-- docguard:last-reviewed 2020-01-01 -->` header DOES fire a freshness warning (the header is respected, not ignored).
+
+---
+
+## Bug 3 (P2): Environment docs extractor misses non-backtick table rows
+
+**Severity**: 🟡 Medium — false positives for vars documented in pipe tables  
+**File**: `cli/validators/environment.mjs:47`
+
+### Root Cause (confirmed in code)
+
+The `documented` set is built exclusively from backtick-quoted var names:
+
+```javascript
+const varRe = /`([A-Z][A-Z0-9_]*[A-Z0-9])`/g;
+while ((m = varRe.exec(content)) !== null) {
+  ...
+  documented.add(m[1]);
+}
+```
+
+Variables documented in a standard markdown pipe table WITHOUT backticks around the name are silently missed:
+
+```markdown
+| DYNAMODB_TABLE_JOBS | DynamoDB table for job records | required |
+```
+→ NOT found (no backticks)
+
+```markdown
+| `DYNAMODB_TABLE_JOBS` | DynamoDB table for job records | required |
+```
+→ Found ✅
+
+Note: `grepEnvUsage()` in `shared-source.mjs` correctly captures the full name from code (no normalization happens there). The bug is in the `documented` extraction only.
+
+### Effect
+
+Projects documenting env vars in clean pipe tables (common DocGuard-generated format) are flagged as "used in code but not documented" despite having complete ENVIRONMENT.md documentation. Every suffixed variant (`DYNAMODB_TABLE_JOBS`, `DYNAMODB_TABLE_SOURCES`, etc.) is flagged separately.
+
+### Fix
+
+Add a pipe-table row parser alongside the backtick parser:
+
+```javascript
+// Also extract pipe-table first columns: | VAR_NAME | ... |
+const tableRe = /^\|\s*([A-Z][A-Z0-9_]*[A-Z0-9])\s*\|/gm;
+while ((m = tableRe.exec(content)) !== null) {
+  if (m[1].length < 3) continue;
+  if (SYSTEM.has(m[1])) continue;
+  documented.add(m[1]);
+}
+```
+
+The fix is additive — backtick extraction continues to work.
+
+### Acceptance Criteria
+
+1. `ENVIRONMENT.md` with `| DYNAMODB_TABLE_JOBS | desc | required |` (no backticks) is treated as documenting `DYNAMODB_TABLE_JOBS`.
+2. `ENVIRONMENT.md` with `` | `DYNAMODB_TABLE_JOBS` | desc | `` (with backticks) continues to work (no regression).
+3. System vars in a pipe table (e.g., `| PATH | ...`) are still excluded via the SYSTEM set.
+
+---
+
+## Bug 4 (P1): Docs-Diff warning omits the failing file path
+
+**Severity**: 🟠 High — warning is completely unactionable without the file name  
+**File**: `cli/validators/docs-diff.mjs:55`
+
+### Root Cause (confirmed in code)
+
+```javascript
+if (stale > 0) parts.push(`${stale} documented but not found in code`);
+warnings.push(`${result.title} drift: ${parts.join(', ')}`);
+```
+
+`result.onlyInDocs` is populated with the actual file names but never referenced in the warning string. The user sees: `"Test Files drift: 1 documented but not found in code"` — no path, no filename.
+
+### Effect
+
+The team audited 52 documented test files against the filesystem manually via `find` and found all 52 exist. The check still fires. Without a filename, there is no way to debug whether this is a false positive or a real gap.
+
+### Fix
+
+Include the offending file paths in the warning (with a reasonable cap):
+
+```javascript
+const MAX_INLINE = 5;
+
+if (stale > 0) {
+  const shown = result.onlyInDocs.slice(0, MAX_INLINE).map(f => `\`${f}\``).join(', ');
+  const extra = result.onlyInDocs.length > MAX_INLINE
+    ? ` (+${result.onlyInDocs.length - MAX_INLINE} more)`
+    : '';
+  parts.push(`${stale} documented but not found in code: ${shown}${extra}`);
+}
+```
+
+Equivalent treatment for `onlyInCode`.
+
+### Acceptance Criteria
+
+1. `"Test Files drift: 1 documented but not found in code"` becomes `"Test Files drift: 1 documented but not found in code: \`src/lib/services/schema-org.test.ts\`"`.
+2. When there are ≤5 offending files, all are listed inline.
+3. When there are >5, the first 5 are listed with `(+N more)`.
+4. The fix suggestion no longer needs to say `/docguard.fix` for a case where the user just needs the filename to investigate.
+
+---
+
+## Bug 5 (P3): Traceability scanner ignores `// @doc` annotations AND misses App Router paths
+
+**Severity**: 🟡 Medium — compound: annotation feature not implemented + TRACE_MAP gap  
+**File**: `cli/validators/traceability.mjs`
+
+### Root Cause (confirmed in code — two issues)
+
+**Issue A**: `// @doc` annotations are NOT implemented. The entire `traceability.mjs` has no annotation scanner. The `TRACE_MAP` only matches on file path patterns.
+
+**Issue B**: The `API-REFERENCE.md` TRACE_MAP entry only matches:
+- `/(routes?|controllers?|handlers?)\//`
+- `/(openapi|swagger)\.(json|ya?ml)/`
+- `/middleware\//`
+
+Next.js App Router route files live at `src/app/api/**` — none of these patterns match. Even a project with a fully populated `src/app/api/` tree will be reported as "API-REFERENCE.md — exists but no matching source code found".
+
+### Effect
+
+A route file with `// @doc API-REFERENCE.md` at line 1 (as shown in templates) still triggers "API-REFERENCE.md — exists but no matching source code found (unlinked doc)". The annotation is documented but inert.
+
+### Fix
+
+**For Issue A** — implement `// @doc` annotation scanning as an override:
+
+```javascript
+// In validateTraceability(), before the TRACE_MAP check:
+const docAnnotations = scanDocAnnotations(projectFiles, projectDir);
+// docAnnotations: Map<docBasename, Set<sourceFilePath>>
+
+// If annotation links the doc to ≥1 source file, count as pass:
+if (docAnnotations.has(docName) && docAnnotations.get(docName).size > 0) {
+  passed++;
+  continue;
+}
+```
+
+```javascript
+function scanDocAnnotations(projectFiles, projectDir) {
+  const map = new Map(); // docBasename → Set<file>
+  const re = /\/\/\s*@doc\s+(\S+\.md)/g;
+  for (const relPath of projectFiles) {
+    const ext = extname(relPath);
+    if (!['.js','.mjs','.ts','.tsx','.jsx'].includes(ext)) continue;
+    const full = resolve(projectDir, relPath);
+    let content;
+    try { content = readFileSync(full, 'utf-8'); } catch { continue; }
+    let m;
+    re.lastIndex = 0;
+    while ((m = re.exec(content)) !== null) {
+      const docName = basename(m[1]);
+      if (!map.has(docName)) map.set(docName, new Set());
+      map.get(docName).add(relPath);
+    }
+  }
+  return map;
+}
+```
+
+**For Issue B** — add Next.js App Router paths to the `API-REFERENCE.md` TRACE_MAP entry:
+
+```diff
+'API-REFERENCE.md': {
+  sourcePatterns: [
+    { label: 'Route handlers', glob: /(routes?|controllers?|handlers?)\// },
++   { label: 'Next.js API routes', glob: /app\/api\// },   // App Router
+    { label: 'OpenAPI spec', glob: /(openapi|swagger)\.(json|ya?ml)/ },
+    { label: 'API middleware', glob: /middleware\// },
+  ],
+},
+```
+
+### Acceptance Criteria
+
+1. A source file with `// @doc API-REFERENCE.md` at the top makes `API-REFERENCE.md` count as "linked" in the traceability check.
+2. A Next.js project with routes under `src/app/api/` does NOT get "API-REFERENCE.md — unlinked doc" if any file under `app/api/` exists.
+3. Both fixes are independent — either one alone prevents the false positive.
+
+---
+
+## Bug 6 (P2): `docguard upgrade --apply` does not update doc files after adding validators
+
+**Severity**: 🟡 Medium — upgrade silently breaks a previously passing Metrics-Consistency check  
+**File**: `cli/commands/upgrade.mjs`
+
+### Root Cause (confirmed in code)
+
+`runUpgrade()` with `--apply` does:
+1. `applyCliUpgrade()` — installs new npm package
+2. `migrateSchema()` — updates `.docguard.json` fields
+
+It does NOT run `fix --write` or update `commands/docguard.guard.md`. When a new CLI version adds validators (e.g., v0.16.0 added `Canonical-Sync`, changing the count from 20 to 21), the doc still says 20 and the Metrics-Consistency validator fires immediately after the upgrade.
+
+### Effect
+
+A project that passes `docguard guard` at v0.16.0 fails Metrics-Consistency immediately after `npm update docguard-cli` to v0.20.0. The user did nothing wrong — the upgrade broke a green check.
+
+### Fix (two-part)
+
+**Minimum viable fix** — print a post-upgrade notice when the validator count changed:
+
+```javascript
+// After CLI upgrade, check if guard command docs need updating:
+const prevCount = getValidatorCountFromGuardDoc(projectDir);
+const newCount = getCurrentValidatorCount();
+if (prevCount !== null && prevCount !== newCount) {
+  console.log(`\n  ${c.yellow}⚠  Validator count changed: ${prevCount} → ${newCount}${c.reset}`);
+  console.log(`     Run ${c.cyan}docguard fix --write${c.reset} to update ${c.dim}commands/docguard.guard.md${c.reset}`);
+}
+```
+
+**Full fix** — run `fix --write` atomically as part of `upgrade --apply`, then print a summary of what changed.
+
+### Acceptance Criteria
+
+1. After `docguard upgrade --apply`, if the validator count changed, the user sees an explicit warning and the exact command to run.
+2. (Full fix) After `docguard upgrade --apply`, `commands/docguard.guard.md` is updated automatically and a summary is printed.
+3. If the validator count did not change, no extra output is produced (no noise for minor upgrades).
+
+---
+
+## Summary Table
+
+| # | Title | File | Severity | Fix size |
+|---|---|---|---|---|
+| 1 | API-Surface path strips wrong prefix for `src/app/api` | `cli/scanners/routes.mjs:112` | 🔴 P0 | 2-line change |
+| 2 | Freshness ignores `docguard:last-reviewed` header | `cli/validators/freshness.mjs` | 🟠 P1 | ~15 lines |
+| 4 | Docs-Diff warning omits file path | `cli/validators/docs-diff.mjs:55` | 🟠 P1 | ~8 lines |
+| 3 | Env docs extractor misses non-backtick table rows | `cli/validators/environment.mjs:47` | 🟡 P2 | ~8 lines |
+| 6 | Upgrade --apply doesn't update validator count docs | `cli/commands/upgrade.mjs` | 🟡 P2 | ~20 lines |
+| 5 | Traceability misses `// @doc` + App Router paths | `cli/validators/traceability.mjs` | 🟡 P3 | ~40 lines |
+
+All fixes are surgical — no schema changes, no new dependencies, no breaking changes. Bugs 1, 2, and 4 together account for the bulk of the user-visible noise from the HugoCross session.
+
+---
+
+*Field test date: 2026-05-26 — hugocross_revamp project, DocGuard v0.20.0*

--- a/tests/docs-diff.test.mjs
+++ b/tests/docs-diff.test.mjs
@@ -59,4 +59,27 @@ describe('Docs-Diff Validator', () => {
     const result = diffTechStack(tmpDir, {});
     assert.ok(!result.onlyInDocs.includes('Docker'), 'Docker should be detected via Dockerfile');
   });
+
+  // Regression for hugocross Bug 4: the docs-diff warning used to emit only
+  // the COUNT ("1 documented but not found in code") and not the file path,
+  // which made it completely unactionable — the user couldn't tell which of
+  // 52 documented tests was the offender. The warning must now name the
+  // file (capped at 5 inline + "(+N more)" for long lists).
+  describe('warning includes the offending file path (hugocross bug 4)', () => {
+    it('names a missing tech-stack entry', async () => {
+      const { validateDocsDiff } = await import('../cli/validators/docs-diff.mjs');
+      // Doc declares Redis; package.json declares NONE → "Redis documented but not found"
+      write(tmpDir, 'docs-canonical/ARCHITECTURE.md', 'Built with Redis.');
+      write(tmpDir, 'package.json', JSON.stringify({
+        name: 'x',
+        dependencies: { express: '^4' },
+      }));
+
+      const { warnings } = validateDocsDiff(tmpDir, {});
+      const drift = warnings.find(w => w.includes('Tech Stack drift'));
+      assert.ok(drift, `expected a tech-stack drift warning, got: ${warnings.join('\n')}`);
+      assert.match(drift, /documented but not found in code: `Redis`/,
+        `warning must name the file/tech; got: ${drift}`);
+    });
+  });
 });

--- a/tests/environment.test.mjs
+++ b/tests/environment.test.mjs
@@ -143,4 +143,66 @@ describe('validateEnvironment', () => {
     assert.equal(results.passed, 3);
     assert.equal(results.warnings.length, 0);
   });
+
+  // Regression for hugocross Bug 3: variables documented in a markdown pipe
+  // table WITHOUT backticks around the name were silently treated as
+  // undocumented, even though they were clearly present in the doc. Both
+  // forms (`| `VAR` | desc |` and `| VAR | desc |`) must now count as
+  // documented; the suffix-strip alternative theory from the original report
+  // turned out NOT to be the actual root cause.
+  it('recognises env vars in markdown table rows without backticks (hugocross bug 3)', () => {
+    fs.writeFileSync(envDocPath, [
+      '## Prerequisites',
+      '## Environment Variables',
+      '',
+      '| Variable              | Description                | Required |',
+      '|-----------------------|----------------------------|----------|',
+      '| DYNAMODB_TABLE_JOBS   | DynamoDB table for jobs    | Yes      |',
+      '| DYNAMODB_TABLE_SOURCES| DynamoDB table for sources | Yes      |',
+      '',
+    ].join('\n'), 'utf-8');
+    fs.mkdirSync(join(tempDir, 'src'), { recursive: true });
+    fs.writeFileSync(join(tempDir, 'src', 'index.js'), [
+      'const a = process.env.DYNAMODB_TABLE_JOBS;',
+      'const b = process.env.DYNAMODB_TABLE_SOURCES;',
+    ].join('\n'), 'utf-8');
+
+    const results = validateEnvironment(tempDir, {});
+    const undocumentedWarning = results.warnings.find(w => w.includes('not documented'));
+    assert.strictEqual(undocumentedWarning, undefined,
+      `expected no undocumented warning; got: ${results.warnings.join('\n')}`);
+  });
+
+  // Regression for v0.20 field-test bug: `grepEnvUsage` only matched
+  // JavaScript env-var access patterns. On a Python project, every
+  // documented env var was reported as "in docs but not in code" because
+  // `os.environ[...]`, `os.environ.get(...)`, and `os.getenv(...)` were all
+  // invisible to the scanner — despite the `explain` command and templates
+  // telling users these forms were supported.
+  it('detects Python os.environ access patterns (v0.20 bug)', () => {
+    fs.writeFileSync(envDocPath, [
+      '## Prerequisites',
+      '## Environment Variables',
+      '',
+      '| Variable              | Description |',
+      '|-----------------------|-------------|',
+      '| `DATABASE_URL`        | DB URL      |',
+      '| `PYTEST_CURRENT_TEST` | Pytest flag |',
+      '| `LOG_LEVEL`           | Log level   |',
+      '',
+    ].join('\n'), 'utf-8');
+    fs.mkdirSync(join(tempDir, 'src'), { recursive: true });
+    fs.writeFileSync(join(tempDir, 'src', 'app.py'), [
+      'import os',
+      'db = os.environ["DATABASE_URL"]',
+      'if os.environ.get("PYTEST_CURRENT_TEST"):',
+      '    pass',
+      'level = os.getenv("LOG_LEVEL")',
+    ].join('\n'), 'utf-8');
+
+    const results = validateEnvironment(tempDir, {});
+    const undocumentedWarning = results.warnings.find(w => w.includes('not documented'));
+    assert.strictEqual(undocumentedWarning, undefined,
+      `expected no undocumented warning; got: ${results.warnings.join('\n')}`);
+  });
 });

--- a/tests/freshness.test.mjs
+++ b/tests/freshness.test.mjs
@@ -159,4 +159,80 @@ describe('Freshness Validator', () => {
     assert.strictEqual(archResult.status, 'warn');
     assert.match(archResult.message, /last updated \d+ days before latest code change/);
   });
+
+  // Regression for the v0.20.0 field-test bug: the `<!-- docguard:last-reviewed
+  // YYYY-MM-DD -->` header was injected into every generated template and
+  // referenced in the freshness fix-suggestion text, but `validateFreshness()`
+  // never actually read it — only `git log` was consulted. So updating the
+  // header (the explicit "I reviewed this and it's still accurate" signal)
+  // had zero effect on the check. These tests pin both the override path
+  // and the git-log fallback path.
+  describe('docguard:last-reviewed header', () => {
+    function commitOldCode(dir) {
+      const oldDate = new Date();
+      oldDate.setDate(oldDate.getDate() - 100);
+      const iso = oldDate.toISOString();
+      for (let i = 1; i <= 3; i++) {
+        writeFileSync(join(dir, `code${i}.js`), `const a = ${i};`);
+        runGit(`add code${i}.js`, dir);
+        execSync(`git commit -m "code ${i}" --date="${iso}"`, {
+          cwd: dir,
+          env: { ...process.env, GIT_COMMITTER_DATE: iso },
+        });
+      }
+    }
+
+    it('a today-dated header suppresses the stale-doc warning', () => {
+      runGit('init', tmpDir);
+      runGit('config user.name "Test"', tmpDir);
+      runGit('config user.email "test@example.com"', tmpDir);
+      commitOldCode(tmpDir);
+
+      // Doc committed 100 days ago, but the header was just stamped today.
+      const oldIso = new Date();
+      oldIso.setDate(oldIso.getDate() - 100);
+      const today = new Date().toISOString().slice(0, 10);
+      const docsDir = join(tmpDir, 'docs-canonical');
+      mkdirSync(docsDir, { recursive: true });
+      writeFileSync(
+        join(docsDir, 'ARCHITECTURE.md'),
+        `<!-- docguard:last-reviewed ${today} -->\n# Arch\n`
+      );
+      runGit('add docs-canonical/ARCHITECTURE.md', tmpDir);
+      const oldIsoStr = oldIso.toISOString();
+      execSync(`git commit -m "doc" --date="${oldIsoStr}"`, {
+        cwd: tmpDir,
+        env: { ...process.env, GIT_COMMITTER_DATE: oldIsoStr },
+      });
+
+      const results = validateFreshness(tmpDir, {});
+      const arch = results.find(r => r.message.includes('ARCHITECTURE.md'));
+      assert.ok(arch, 'ARCHITECTURE.md should appear in results');
+      assert.strictEqual(arch.status, 'pass',
+        `expected pass (header is fresh) but got ${arch.status}: ${arch.message}`);
+    });
+
+    it('a stale-dated header does NOT suppress the warning', () => {
+      runGit('init', tmpDir);
+      runGit('config user.name "Test"', tmpDir);
+      runGit('config user.email "test@example.com"', tmpDir);
+      commitOldCode(tmpDir);
+
+      const docsDir = join(tmpDir, 'docs-canonical');
+      mkdirSync(docsDir, { recursive: true });
+      // Header date is 200 days old → should still trigger staleness.
+      writeFileSync(
+        join(docsDir, 'ARCHITECTURE.md'),
+        '<!-- docguard:last-reviewed 2020-01-01 -->\n# Arch\n'
+      );
+      runGit('add docs-canonical/ARCHITECTURE.md', tmpDir);
+      runGit('commit -m "doc"', tmpDir);
+
+      const results = validateFreshness(tmpDir, {});
+      const arch = results.find(r => r.message.includes('ARCHITECTURE.md'));
+      assert.ok(arch);
+      assert.strictEqual(arch.status, 'warn',
+        'stale header date must not mask a real freshness warning');
+    });
+  });
 });

--- a/tests/routes-nextjs-app-router.test.mjs
+++ b/tests/routes-nextjs-app-router.test.mjs
@@ -1,0 +1,72 @@
+/**
+ * Regression: Next.js App Router HTTP path emission.
+ *
+ * Bug (v0.20.0 field test, hugocross_revamp): for projects using the `src/`
+ * layout, the API-Surface code-scan emitted `GET /app/api/health` instead of
+ * `GET /api/health`. Root cause: `appDir.split('/')[0]` stripped only the
+ * first segment (`src/`) when computing the route's relative path, leaking
+ * `app/` into the emitted HTTP path. Fix: strip everything up to and
+ * including the last `/` (the parent of `api/`).
+ *
+ * These tests pin both layouts so the bug cannot regress.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { scanRoutesDeep } from '../cli/scanners/routes.mjs';
+
+const NO_SPEC = { openapi: { found: false } };
+
+function make(files) {
+  const dir = mkdtempSync(join(tmpdir(), 'docguard-nextjs-'));
+  for (const [rel, content] of Object.entries(files)) {
+    const full = join(dir, rel);
+    mkdirSync(join(full, '..'), { recursive: true });
+    writeFileSync(full, content);
+  }
+  return dir;
+}
+
+describe('Next.js App Router — HTTP path emission', () => {
+  let dir;
+  afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+  it('emits /api/health (not /app/api/health) for the src/ layout', () => {
+    dir = make({
+      'package.json': JSON.stringify({ dependencies: { next: '^15' } }),
+      'src/app/api/health/route.ts': 'export async function GET() {}',
+    });
+    const routes = scanRoutesDeep(dir, { framework: 'Next.js' }, NO_SPEC);
+    const paths = routes.map(r => `${r.method} ${r.path}`);
+    assert.ok(paths.includes('GET /api/health'),
+      `expected 'GET /api/health' in ${JSON.stringify(paths)}`);
+    assert.ok(!paths.some(p => p.includes('/app/api/')),
+      `no route should leak '/app/api/' prefix; got ${JSON.stringify(paths)}`);
+  });
+
+  it('emits /api/health for the non-src layout (no regression)', () => {
+    dir = make({
+      'package.json': JSON.stringify({ dependencies: { next: '^15' } }),
+      'app/api/health/route.ts': 'export async function GET() {}',
+    });
+    const routes = scanRoutesDeep(dir, { framework: 'Next.js' }, NO_SPEC);
+    const paths = routes.map(r => `${r.method} ${r.path}`);
+    assert.ok(paths.includes('GET /api/health'),
+      `expected 'GET /api/health' in ${JSON.stringify(paths)}`);
+  });
+
+  it('preserves nested segments for the src/ layout', () => {
+    dir = make({
+      'package.json': JSON.stringify({ dependencies: { next: '^15' } }),
+      'src/app/api/users/[id]/posts/route.ts': 'export async function GET() {}',
+    });
+    const routes = scanRoutesDeep(dir, { framework: 'Next.js' }, NO_SPEC);
+    const paths = routes.map(r => `${r.method} ${r.path}`);
+    assert.ok(paths.includes('GET /api/users/:id/posts'),
+      `expected 'GET /api/users/:id/posts' in ${JSON.stringify(paths)}`);
+  });
+});

--- a/tests/surface-sync.test.mjs
+++ b/tests/surface-sync.test.mjs
@@ -1,0 +1,339 @@
+/**
+ * Surface-Sync validator tests.
+ *
+ * Pins the validator against the exact class of bugs it was built for:
+ * a code-derived enumerable list (commands, validators, slash commands)
+ * exists in code but is silently missing from the README's table. The
+ * count-based canonical-sync passes on this scenario; surface-sync must
+ * catch it.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { validateSurfaceSync } from '../cli/validators/surface-sync.mjs';
+
+function write(dir, rel, content) {
+  const full = join(dir, rel);
+  mkdirSync(join(full, '..'), { recursive: true });
+  writeFileSync(full, content);
+}
+
+describe('Surface-Sync validator', () => {
+  let tmp;
+  beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'docguard-surface-sync-')); });
+  afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+  it('returns N/A (total 0) when no surfaces are configured', () => {
+    write(tmp, 'README.md', '# X\n| `guard` | description |\n');
+    const r = validateSurfaceSync(tmp, {});
+    assert.equal(r.total, 0);
+    assert.equal(r.warnings.length, 0);
+    assert.equal(r.errors.length, 0);
+  });
+
+  it('flags a command implemented in code but missing from the README table', () => {
+    // Code-truth: cli/commands/{guard,demo}.mjs
+    write(tmp, 'cli/commands/guard.mjs', 'export {};');
+    write(tmp, 'cli/commands/demo.mjs', 'export {};');
+
+    // README documents `guard` only (table form). `demo` mentioned in prose
+    // is NOT a documented list entry — should still be reported as missing.
+    write(tmp, 'README.md', [
+      '# Project',
+      '',
+      'Try `npx docguard-cli demo` for a quick preview.',  // prose mention only
+      '',
+      '## Commands',
+      '',
+      '| Command | Description |',
+      '|---------|-------------|',
+      '| `guard` | Run validation |',
+      '',
+    ].join('\n'));
+
+    const config = {
+      surfaceSync: {
+        surfaces: [
+          { name: 'commands', glob: 'cli/commands/*.mjs', extract: 'basename-no-ext', docs: ['README.md'] },
+        ],
+      },
+    };
+
+    const r = validateSurfaceSync(tmp, config);
+    assert.equal(r.total, 1, 'one (surface, doc) pair was checked');
+    assert.equal(r.passed, 0, 'should not pass — demo is missing from the table');
+    assert.equal(r.warnings.length, 1);
+    assert.match(r.warnings[0], /Surface "commands" drift/);
+    assert.match(r.warnings[0], /`demo`/);
+    assert.match(r.warnings[0], /missing from README\.md/);
+  });
+
+  it('passes when every code item is documented in a table row', () => {
+    write(tmp, 'cli/commands/guard.mjs', 'export {};');
+    write(tmp, 'cli/commands/demo.mjs', 'export {};');
+    write(tmp, 'README.md', [
+      '## Commands',
+      '| Command | Description |',
+      '|---------|-------------|',
+      '| `guard` | Run validation |',
+      '| `demo`  | Quick preview |',
+      '',
+    ].join('\n'));
+
+    const config = {
+      surfaceSync: {
+        surfaces: [
+          { name: 'commands', glob: 'cli/commands/*.mjs', extract: 'basename-no-ext', docs: ['README.md'] },
+        ],
+      },
+    };
+
+    const r = validateSurfaceSync(tmp, config);
+    assert.equal(r.passed, 1);
+    assert.equal(r.warnings.length, 0);
+  });
+
+  it('respects the `ignore` list (deprecation aliases not flagged)', () => {
+    write(tmp, 'cli/commands/guard.mjs', 'export {};');
+    write(tmp, 'cli/commands/setup.mjs', 'export {};'); // deprecation alias
+
+    write(tmp, 'README.md', [
+      '## Commands',
+      '| Command | Description |',
+      '|---------|-------------|',
+      '| `guard` | Run validation |',
+      '',
+    ].join('\n'));
+
+    const config = {
+      surfaceSync: {
+        surfaces: [
+          {
+            name: 'commands',
+            glob: 'cli/commands/*.mjs',
+            extract: 'basename-no-ext',
+            ignore: ['setup'],
+            docs: ['README.md'],
+          },
+        ],
+      },
+    };
+
+    const r = validateSurfaceSync(tmp, config);
+    assert.equal(r.passed, 1, 'setup is ignored, so the doc is complete');
+    assert.equal(r.warnings.length, 0);
+  });
+
+  it('flags a doc item with no corresponding code file (removed surface)', () => {
+    write(tmp, 'cli/commands/guard.mjs', 'export {};');
+    write(tmp, 'README.md', [
+      '## Commands',
+      '| Command | Description |',
+      '|---------|-------------|',
+      '| `guard`  | Run validation |',
+      '| `ancient` | Doesn\'t exist anymore |',
+      '',
+    ].join('\n'));
+
+    const config = {
+      surfaceSync: {
+        surfaces: [
+          { name: 'commands', glob: 'cli/commands/*.mjs', extract: 'basename-no-ext', docs: ['README.md'] },
+        ],
+      },
+    };
+
+    const r = validateSurfaceSync(tmp, config);
+    assert.equal(r.warnings.length, 1);
+    assert.match(r.warnings[0], /`ancient`/);
+    assert.match(r.warnings[0], /listed in README\.md but not found in code/);
+  });
+
+  it('does NOT count backticks inside fenced code blocks as documented entries', () => {
+    write(tmp, 'cli/commands/guard.mjs', 'export {};');
+    write(tmp, 'cli/commands/demo.mjs', 'export {};');
+    // README has a code block that LOOKS like a list but is just a shell example.
+    // Fenced code is stripped before list-context scanning, so `demo` should
+    // still be reported as missing.
+    write(tmp, 'README.md', [
+      '## Commands',
+      '```',
+      'docguard guard',
+      'docguard demo',
+      '```',
+      '',
+      '| `guard` | only one in the real table |',
+      '',
+    ].join('\n'));
+
+    const config = {
+      surfaceSync: {
+        surfaces: [
+          { name: 'commands', glob: 'cli/commands/*.mjs', extract: 'basename-no-ext', docs: ['README.md'] },
+        ],
+      },
+    };
+
+    const r = validateSurfaceSync(tmp, config);
+    assert.equal(r.warnings.length, 1);
+    assert.match(r.warnings[0], /`demo`/, 'demo is in code but only in a code block, not in any table — should warn');
+  });
+
+  it('detects bullet-list entries as documented items', () => {
+    write(tmp, 'cli/commands/guard.mjs', 'export {};');
+    write(tmp, 'cli/commands/demo.mjs', 'export {};');
+    write(tmp, 'README.md', [
+      '## Commands',
+      '',
+      '- `guard` — run validation',
+      '- `demo` — quick preview',
+      '',
+    ].join('\n'));
+
+    const config = {
+      surfaceSync: {
+        surfaces: [
+          { name: 'commands', glob: 'cli/commands/*.mjs', extract: 'basename-no-ext', docs: ['README.md'] },
+        ],
+      },
+    };
+
+    const r = validateSurfaceSync(tmp, config);
+    assert.equal(r.passed, 1, 'bullet-list items count as documented');
+    assert.equal(r.warnings.length, 0);
+  });
+
+  it('strips the `docguard ` prefix when extracting from table cells', () => {
+    write(tmp, 'cli/commands/guard.mjs', 'export {};');
+    write(tmp, 'README.md', [
+      '## Commands',
+      '| Command | Description |',
+      '|---------|-------------|',
+      '| `docguard guard` | Run validation |',
+      '',
+    ].join('\n'));
+
+    const config = {
+      surfaceSync: {
+        surfaces: [
+          { name: 'commands', glob: 'cli/commands/*.mjs', extract: 'basename-no-ext', docs: ['README.md'] },
+        ],
+      },
+    };
+
+    const r = validateSurfaceSync(tmp, config);
+    assert.equal(r.passed, 1, 'docguard-prefixed entries should still match the bare command name');
+  });
+
+  it('handles multiple target docs independently', () => {
+    write(tmp, 'cli/commands/guard.mjs', 'export {};');
+    write(tmp, 'README.md', '| `guard` | x |\n');
+    write(tmp, 'AGENTS.md', '## Commands\n(no commands listed)\n');
+
+    const config = {
+      surfaceSync: {
+        surfaces: [
+          { name: 'commands', glob: 'cli/commands/*.mjs', extract: 'basename-no-ext', docs: ['README.md', 'AGENTS.md'] },
+        ],
+      },
+    };
+
+    const r = validateSurfaceSync(tmp, config);
+    assert.equal(r.total, 2, 'one (surface, doc) pair per doc');
+    assert.equal(r.passed, 1, 'README is complete');
+    assert.equal(r.warnings.length, 1, 'AGENTS.md is missing guard');
+    assert.match(r.warnings[0], /AGENTS\.md/);
+  });
+
+  it('scopes scanning to a specific section when `section` is set', () => {
+    // Two tables in one README: a Commands table and a Validators table. Without
+    // section-scoping, the commands surface would also see validator names and
+    // produce cross-table false positives.
+    write(tmp, 'cli/commands/guard.mjs', 'export {};');
+    write(tmp, 'cli/commands/demo.mjs', 'export {};');
+    write(tmp, 'README.md', [
+      '# Project',
+      '',
+      '## Commands',
+      '',
+      '| Command | Description |',
+      '|---------|-------------|',
+      '| `guard` | Run validation |',
+      '| `demo`  | Quick preview |',
+      '',
+      '## Validators',
+      '',
+      '| Validator | Description |',
+      '|-----------|-------------|',
+      '| `api-surface` | API drift |',
+      '| `freshness`   | Doc age |',
+      '',
+    ].join('\n'));
+
+    // Without section scoping, the commands surface would think `api-surface`
+    // and `freshness` were "documented commands missing from code".
+    const config = {
+      surfaceSync: {
+        surfaces: [
+          {
+            name: 'commands',
+            glob: 'cli/commands/*.mjs',
+            extract: 'basename-no-ext',
+            docs: ['README.md'],
+            section: 'Commands',
+          },
+        ],
+      },
+    };
+
+    const r = validateSurfaceSync(tmp, config);
+    assert.equal(r.passed, 1, `should pass: scope limited to Commands section; warnings: ${r.warnings.join('\n')}`);
+    assert.equal(r.warnings.length, 0,
+      'no cross-table false positives expected when section is scoped');
+  });
+
+  it('warns sensibly when the configured section heading is absent from the doc', () => {
+    write(tmp, 'cli/commands/guard.mjs', 'export {};');
+    write(tmp, 'README.md', '# Empty doc with no commands section\n');
+
+    const config = {
+      surfaceSync: {
+        surfaces: [
+          {
+            name: 'commands',
+            glob: 'cli/commands/*.mjs',
+            extract: 'basename-no-ext',
+            docs: ['README.md'],
+            section: 'Commands',
+          },
+        ],
+      },
+    };
+
+    const r = validateSurfaceSync(tmp, config);
+    // Section missing → empty scope → all code items report as missing.
+    // That's the right behavior: the user said "scope to Commands" and it
+    // doesn't exist, so the doc has no documented commands.
+    assert.equal(r.warnings.length, 1);
+    assert.match(r.warnings[0], /`guard`/);
+    assert.match(r.warnings[0], /missing from README\.md/);
+  });
+
+  it('returns silently when the surface glob matches nothing', () => {
+    write(tmp, 'README.md', '# x\n');
+    const config = {
+      surfaceSync: {
+        surfaces: [
+          { name: 'commands', glob: 'nonexistent/*.mjs', extract: 'basename-no-ext', docs: ['README.md'] },
+        ],
+      },
+    };
+    const r = validateSurfaceSync(tmp, config);
+    assert.equal(r.total, 0);
+    assert.equal(r.warnings.length, 0);
+  });
+});

--- a/tests/traceability.test.mjs
+++ b/tests/traceability.test.mjs
@@ -144,4 +144,49 @@ describe('Traceability Validator', () => {
     );
     assert.strictEqual(hasOrphanedWarning, true);
   });
+
+  // Regression for hugocross Bug 5 (compound):
+  //   (a) `// @doc API-REFERENCE.md` annotations were documented in templates
+  //       but never actually scanned — they had zero effect on traceability.
+  //   (b) Next.js App Router route files (`src/app/api/...`) did not match
+  //       any TRACE_MAP pattern, so a fully-populated API tree was reported
+  //       as "API-REFERENCE.md — unlinked doc".
+  describe('@doc annotations and Next.js App Router (hugocross bug 5)', () => {
+    it('@doc annotation links a source file to a canonical doc', () => {
+      mkdirSync(join(tmpDir, 'docs-canonical'), { recursive: true });
+      writeFileSync(join(tmpDir, 'docs-canonical', 'API-REFERENCE.md'), '# API');
+      // Source file lives OUTSIDE any of the TRACE_MAP path globs
+      // (routes/, controllers/, handlers/, app/api/, middleware/, openapi.*)
+      // — only the @doc annotation can link it.
+      mkdirSync(join(tmpDir, 'src', 'weird-place'), { recursive: true });
+      writeFileSync(
+        join(tmpDir, 'src', 'weird-place', 'thing.ts'),
+        '// @doc API-REFERENCE.md\nexport const foo = 1;\n'
+      );
+
+      const config = { requiredFiles: { canonical: ['API-REFERENCE.md'] } };
+      const result = validateTraceability(tmpDir, config);
+      assert.strictEqual(result.passed, 1,
+        `annotation should count as a link; warnings: ${result.warnings.join('\n')}`);
+      assert.ok(
+        !result.warnings.some(w => w.includes('API-REFERENCE.md — exists but no matching')),
+        'no unlinked-doc warning expected when @doc annotation is present'
+      );
+    });
+
+    it('Next.js App Router src/app/api/ is recognised by TRACE_MAP', () => {
+      mkdirSync(join(tmpDir, 'docs-canonical'), { recursive: true });
+      writeFileSync(join(tmpDir, 'docs-canonical', 'API-REFERENCE.md'), '# API');
+      mkdirSync(join(tmpDir, 'src', 'app', 'api', 'health'), { recursive: true });
+      writeFileSync(
+        join(tmpDir, 'src', 'app', 'api', 'health', 'route.ts'),
+        'export async function GET() {}'
+      );
+
+      const config = { requiredFiles: { canonical: ['API-REFERENCE.md'] } };
+      const result = validateTraceability(tmpDir, config);
+      assert.strictEqual(result.passed, 1,
+        `App Router route should link to API-REFERENCE.md; warnings: ${result.warnings.join('\n')}`);
+    });
+  });
 });


### PR DESCRIPTION
## Release v0.22.0 (MINOR)

Batched minor release. **MINOR** bump (not patch) because it adds a new validator.

### Added — Surface-Sync validator
Item-level enumerable drift: names in doc tables/lists (commands, validators, slash-commands, …) must match code-truth. Complements the existing count-level Canonical-Sync. **N/A by default** — opt-in per project via `surfaceSync.surfaces` in `.docguard.json`, so existing projects upgrade with zero new noise. Adds two optional, backward-compatible properties to the config schema (`surfaceSync`, `canonicalSync`).

### Fixed — 8 field-test bugs from v0.20.0
Confirmed against real Python + Next.js 15 App Router codebases, each reproduced in source and pinned with a regression test:
1. Next.js App Router `src/` layout emitted `GET /app/api/X` instead of `/api/X`
2. Freshness ignored `<!-- docguard:last-reviewed -->` headers
3. Env-var pipe-table rows (no backticks) treated as undocumented
4. Docs-Diff warnings now name file paths (up to 5 + `(+N more)`)
5. Traceability ignored `// @doc` annotations + missed App Router paths
6. `upgrade --apply` nudges `fix --write` for validator-count drift
7. Python env-var support (`os.environ`, `.get()`, `os.getenv()`)
8. `memory`/`score` metric label disambiguated → "Claim match rate"

### Release prep in this PR
- Bump 0.21.1 → 0.22.0; CHANGELOG `[Unreleased]` → `[0.22.0]`
- Dogfooding: reconciled our own docs with the 24th validator (counts, mermaid, validator table, Usage `demo` row). Surface-Sync caught a **real** drift in our own README Slash Commands table — added `/docguard.init` + `/docguard.update`, removed `/docguard.score` (no such slash-command template).

### Gates
- ✅ 632/632 tests pass
- ✅ `docguard guard` exits 0 (25 remaining warnings all pre-existing, none introduced here)

🤖 Reviewed by parallel agents (SHIP verdict); prepped + verified with Claude Code.