### PR TITLE
⚡ Bolt: [performance improvement] Optimize OpenAPI relationship extraction

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-18 - [O(N*M) String Overhead]
 **Learning:** To prevent N^2 performance bottlenecks in nested loops (such as comparing a list of items against multiple documents), precomputing expensive operations like `.toLowerCase()` during the initial file load or mapping phase avoids redundant $O(N \times M)$ overhead.
 **Action:** Precompute expensive string operations and property lookups (like `.toLowerCase()` and `.substring()`) outside of inner loops and during file load mapping phases to improve scaling.
+
+## 2024-05-18 - [O(N^2) Array Search Overhead]
+**Learning:** In `extractOpenAPIRelationships`, searching an array inside a nested loop with `Array.find` creates an O(N^2) bottleneck.
+**Action:** Precompute an O(1) `Map` lookup (e.g. of lowercased schema names to schema objects) outside the loop to reduce complexity to O(N).

--- a/cli/scanners/schemas.mjs
+++ b/cli/scanners/schemas.mjs
@@ -667,11 +667,19 @@ function scanRailsModels(dir) {
 
 function extractOpenAPIRelationships(schemas) {
   const relationships = [];
+
+  // Optimization: Precompute an O(1) Map lookup of lowercased schema names
+  // to avoid an O(N^2) algorithmic bottleneck caused by a nested Array.find.
+  const schemaMap = new Map();
+  for (const schema of schemas) {
+    schemaMap.set(schema.name.toLowerCase(), schema);
+  }
+
   for (const schema of schemas) {
     for (const field of schema.fields) {
       if (field.type !== 'string' && field.type !== 'number' && field.type !== 'boolean' && field.type !== 'integer') {
         // Likely a reference to another schema
-        const target = schemas.find(s => s.name.toLowerCase() === field.type.toLowerCase());
+        const target = schemaMap.get(field.type.toLowerCase());
         if (target) {
           relationships.push({
             from: schema.name,


### PR DESCRIPTION
💡 **What**: Replaced an `Array.find()` nested search with a precomputed O(1) `Map` lookup of lowercased schema names inside `extractOpenAPIRelationships` in `cli/scanners/schemas.mjs`.

🎯 **Why**: When analyzing large OpenAPI specifications, searching an array inside a nested loop with `Array.find` creates an $O(N^2)$ algorithmic bottleneck, scaling poorly as the number of schemas and fields grows. This eliminates the redundant N-lookup by caching the target names in $O(1)$ lookup complexity, making it an $O(N)$ operation instead.

📊 **Impact**: Reduces total iterations inside the loop, preventing potential O(N^2) freeze for large schema arrays. Complexity reduced from $O(N^2)$ to $O(N)$.

🔬 **Measurement**: Measure the time spent in `extractOpenAPIRelationships` for OpenAPI specifications with >1,000 schemas. Verify no test regressions via `node --test tests/*.test.mjs`.

---
*PR created automatically by Jules for task [3410059755640564557](https://jules.google.com/task/3410059755640564557) started by @raccioly*