### PR TITLE
🎨 Palette: [UX improvement] Add loading spinner to score refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ dist/
 *.egg-info/
 __pycache__/
 .venv
+.docguard/

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-04-16 - Context-Aware Status Bar Tooltips
 **Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
 **Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+
+## 2024-05-18 - Yielding Event Loop for Loading States
+**Learning:** When updating UI elements like VS Code extension `statusBarItem` to show a loading state (e.g., adding a spinner and changing tooltip) immediately prior to a synchronous, blocking operation (like `execSync`), the changes won't render unless you explicitly yield the event loop.
+**Action:** Use `await new Promise(r => setTimeout(r, 0))` right after the UI update to allow the editor time to render the visual changes before the main thread blocks.

--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -209,10 +209,18 @@ async function refreshScore() {
   if (!dir) return;
 
   try {
+    statusBarItem.text = '$(sync~spin) CDD: Loading...';
+    statusBarItem.tooltip = 'Calculating CDD Score...';
+    statusBarItem.backgroundColor = undefined;
+    statusBarItem.show();
+    await new Promise(r => setTimeout(r, 0));
+
     const output = execSpecguard(dir, 'score --format json');
     const jsonStart = output.indexOf('{');
     if (jsonStart < 0) {
       statusBarItem.text = '$(shield) CDD: ?';
+      statusBarItem.tooltip = 'Error calculating CDD Score (invalid output)';
+      statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
       statusBarItem.show();
       return;
     }
@@ -243,6 +251,8 @@ async function refreshScore() {
     outputChannel.appendLine(`Score refreshed: ${score}/100 (${grade})`);
   } catch (e) {
     statusBarItem.text = '$(shield) CDD: ?';
+    statusBarItem.tooltip = `Score refresh error: ${e.message}`;
+    statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.errorBackground');
     statusBarItem.show();
     outputChannel.appendLine(`Score refresh error: ${e.message}`);
   }


### PR DESCRIPTION
💡 **What:** 
Added a loading state (`$(sync~spin)`) and a 'Calculating CDD Score...' tooltip to the VS Code status bar item before it executes the synchronous `refreshScore` command.

🎯 **Why:** 
The `execSpecguard` command uses `execSync`, which is a blocking, synchronous operation that freezes the Node.js event loop. Previously, this meant the user had no feedback while the score was calculating. By setting the loading UI state and explicitly yielding the event loop with `await new Promise(r => setTimeout(r, 0))`, we give the VS Code Extension Host time to render the visual update before the main thread is blocked. Additionally, explicitly resetting `statusBarItem.backgroundColor = undefined` ensures that red error states from a previous failed run don't persist during the new run.

📸 **Before/After:** 
**Before:** Clicking "CDD Score" would freeze the editor momentarily without visual feedback until the command succeeded or failed. Stale red error backgrounds could persist during a new refresh attempt.
**After:** Clicking the score immediately shows a spinning icon and a "Calculating" tooltip before freezing. Previous error backgrounds are cleanly cleared.

♿ **Accessibility:**
Provides immediate contextual feedback (via a spinning icon and clear tooltip) on user action and status context changes, improving cognitive predictability.

---
*PR created automatically by Jules for task [180131259087810144](https://jules.google.com/task/180131259087810144) started by @raccioly*