### PR TITLE
release: v0.22.1 — honest self-audit + field-feedback fixes

### DIFF
--- a/.agent/skills/docguard-fix/SKILL.md
+++ b/.agent/skills/docguard-fix/SKILL.md
@@ -6,10 +6,10 @@ description: AI-driven documentation repair with structured research workflow, t
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.0
+  version: 0.22.1
   source: extensions/spec-kit-docguard/skills/docguard-fix
 ---
-<!-- docguard:version: 0.22.0 -->
+<!-- docguard:version: 0.22.1 -->
 
 # DocGuard Fix Skill
 

--- a/.agent/skills/docguard-guard/SKILL.md
+++ b/.agent/skills/docguard-guard/SKILL.md
@@ -7,10 +7,10 @@ description: Run DocGuard guard validation against Canonical-Driven Development 
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.0
+  version: 0.22.1
   source: extensions/spec-kit-docguard/skills/docguard-guard
 ---
-<!-- docguard:version: 0.22.0 -->
+<!-- docguard:version: 0.22.1 -->
 
 # DocGuard Guard Skill
 
@@ -24,7 +24,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Goal
 
-Execute DocGuard's 19-validator guard suite against the current project, parse structured results, triage findings by severity and impact, and produce an actionable remediation plan. This skill transforms raw CLI output into an AI-digestible quality assessment.
+Execute DocGuard's full guard validator suite against the current project, parse structured results, triage findings by severity and impact, and produce an actionable remediation plan. This skill transforms raw CLI output into an AI-digestible quality assessment.
 
 ## Pre-Execution Checks
 

--- a/.agent/skills/docguard-review/SKILL.md
+++ b/.agent/skills/docguard-review/SKILL.md
@@ -6,10 +6,10 @@ description: Cross-document consistency analysis and quality assessment. Perform
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.0
+  version: 0.22.1
   source: extensions/spec-kit-docguard/skills/docguard-review
 ---
-<!-- docguard:version: 0.22.0 -->
+<!-- docguard:version: 0.22.1 -->
 
 # DocGuard Review Skill
 

--- a/.agent/skills/docguard-score/SKILL.md
+++ b/.agent/skills/docguard-score/SKILL.md
@@ -6,10 +6,10 @@ description: CDD maturity assessment with category-aware improvement roadmap. Ru
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.0
+  version: 0.22.1
   source: extensions/spec-kit-docguard/skills/docguard-score
 ---
-<!-- docguard:version: 0.22.0 -->
+<!-- docguard:version: 0.22.1 -->
 
 # DocGuard Score Skill
 

--- a/.agent/skills/docguard-sync/SKILL.md
+++ b/.agent/skills/docguard-sync/SKILL.md
@@ -4,7 +4,7 @@ description: Keep canonical documentation ALWAYS UP TO DATE. Refreshes code-trut
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.0
+  version: 0.22.1
   source: extensions/spec-kit-docguard/skills/docguard-sync
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Dependencies
 node_modules/
 
+# Build artifacts (npm pack output — never commit)
+*.tgz
+
 # Internal research (not part of the public package)
 Research/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-05-29
+
+Self-audit + field-feedback patch. Honest fixes only — no doc-gaming. The
+remaining guard warnings (Spec-Kit on bugfix specs, negation-load, docs-diff
+test files, freshness lag, the demo↔docguard import cycle) are deferred to
+v0.23.0 because the *correct* fix is improving the validators, not papering
+over the docs. `sync --write` confirmed the freshness warnings are git-age
+lag, not real code-truth drift, so they were left honest rather than date-bumped.
+
+### Fixed
+- **Stale validator counts in scaffolded files** — `extensions/spec-kit-docguard/skills/docguard-guard/SKILL.md`
+  ("19-validator") and `extensions/spec-kit-docguard/commands/guard.md` ("19-validator", "20 total")
+  hardcoded counts that drift every release and shipped into user projects. Reworded to be count-free,
+  matching the already-fixed `templates/commands/docguard.guard.md`. (Field report, Issue 1.)
+- **REQUIREMENTS.md non-functional requirements were unfilled web-service boilerplate**
+  ("200ms p95", "99.9% uptime SLA") — nonsensical for a zero-dependency CLI and untraced.
+  Rewrote NFR-001/002/003 to DocGuard's real, test-backed NFRs (injection-safe subprocess
+  spawns, zero runtime deps, cross-process plan cache) and traced each to its regression test
+  via `@req` tags. Clears the 3 Traceability warnings honestly.
+- **`specs/002-fix-test-discovery/plan.md`** — added the Spec-Kit-mandated `Summary` and
+  `Project Structure` sections (real content).
+
+### Added / Improved
+- **`docguard explain canonical-sync`** — the count-level companion validator was missing from
+  the explainer table; added it. (Field report, Issue 10.)
+- **Test-Spec validator note** now points to the expected table format and `docguard explain` when
+  it finds no service-to-test mappings, instead of a dead-end message. (Field report, Issue 4.)
+
+### Docs
+- **README "What's New" no longer over-claims language-aware trace mapping for `guard`.** The
+  multilingual patterns live in the standalone `docguard trace` command; the guard-time
+  Traceability validator is JS/TS-first today, with language parity on the v0.23 roadmap.
+  (Field report, Issue 3 — honesty fix pending the full validator port.)
+
 ## [0.22.0] - 2026-05-28
 
 ### Added — Surface-Sync validator (item-level enumerable drift)

--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ Recent highlights across the v0.16 → v0.19 line:
   two commits. Pinpoints regressions without re-running the full suite by hand.
 - **`docguard upgrade --apply --pr`** — when the config schema bumps, DocGuard migrates
   `.docguard.json` for you and (optionally) opens a PR with the change.
-- **Language-aware patterns** — test discovery and trace mapping now understand Python, Rust, Go,
-  Java, Ruby, and PHP layouts in addition to JS/TS. Sensible defaults, override via config.
+- **Language-aware `docguard trace`** — the standalone `trace` command understands Python, Rust, Go,
+  Java, Ruby, and PHP layouts in addition to JS/TS. (The guard-time Traceability validator is JS/TS-first
+  today; broader language parity is on the v0.23 roadmap.)
 - **Per-validator severity overrides** — escalate `freshness` to `high` for production repos,
   demote `doc-quality` to `low` for prototypes. Configurable per-project.
 - **JSON Schema for `.docguard.json`** — IDE autocomplete, in-line docs, and validation via

--- a/cli/commands/explain.mjs
+++ b/cli/commands/explain.mjs
@@ -150,6 +150,17 @@ const EXPLAINERS = {
     example: 'AGENTS.md says "22 validators" and `docguard guard` shows 22 active validators',
     standard: 'CDD principle: documented metrics match reality',
   },
+  canonicalSync: {
+    title: 'Canonical-Sync — README count claims match code-truth (DocGuard repo only)',
+    what: 'Count-level check (complementing surface-sync\'s item-level check). Verifies that numeric claims in the README — "ships N commands", "N validators", mermaid diagram counts — match what the code actually exposes. N/A unless the project opts in via `canonicalSync` config; primarily for DocGuard\'s own repo.',
+    why:  'Hardcoded counts in prose and diagrams drift silently every time a command or validator is added/removed. A README claiming "23 validators" when there are 24 erodes trust and misleads AI agents reading the docs.',
+    triggers: [
+      ['README.md claims "N validators" but guard reports M', 'Update the count. `docguard fix --write` handles this mechanically across all docs.'],
+      ['architecture diagram has stale counts', 'Update the count inside the mermaid block (fix --write does not edit mermaid; do it manually).'],
+    ],
+    example: 'README says "24 validators" and the architecture mermaid says "Validators (24)" — both matching the live registry',
+    standard: 'CDD principle: documented counts match implemented counts',
+  },
   surfaceSync: {
     title: 'Surface-Sync — every code-derived list entry is documented',
     what: 'Item-level check (complementing canonical-sync\'s count-level check). For each configured surface (e.g. commands → `cli/commands/*.mjs`), compares the discovered files against the names appearing in table rows / bullet lists in target docs (README.md, AGENTS.md). Warns when a code item is missing from the doc, or a doc item is missing from code.',

--- a/cli/validators/test-spec.mjs
+++ b/cli/validators/test-spec.mjs
@@ -175,7 +175,7 @@ export function validateTestSpec(projectDir, config) {
 
     if (hasTestDir || hasColocated || hasConfigTests) {
       // Tests exist but the spec maps none of them → not applicable, not a pass.
-      results.note = 'TEST-SPEC.md declares no service-to-test mappings';
+      results.note = 'TEST-SPEC.md declares no service-to-test mappings. Add a "## Source-to-Test Map" table with `| Source | Test file | Status |` columns — run `docguard explain "no service-to-test mappings"` for the exact format.';
     } else {
       results.warnings.push(
         'No test directory or co-located test files found. ' +

--- a/docs-canonical/REQUIREMENTS.md
+++ b/docs-canonical/REQUIREMENTS.md
@@ -22,11 +22,11 @@
 
 <!-- Quality attributes: performance, security, reliability -->
 
-| ID | Category | Requirement | Metric |
-|----|----------|-------------|--------|
-| NFR-001 | Performance | Response time < 200ms p95 | Measured via [tool] |
-| NFR-002 | Security | All endpoints require authentication | Validated by guard |
-| NFR-003 | Reliability | 99.9% uptime SLA | Monitored via [tool] |
+| ID | Category | Requirement | Verified by |
+|----|----------|-------------|-------------|
+| NFR-001 | Security | CLI subprocess invocations are injection-safe — agent/config-derived values are allowlist-validated and passed via `execFileSync` (no shell interpolation of untrusted input) | `tests/security-init-injection.test.mjs` |
+| NFR-002 | Portability | The published package runs with **zero runtime dependencies** on Node.js ≥18 — the packaged tarball executes standalone | `tests/npm-pack-smoke.test.mjs` |
+| NFR-003 | Performance | Repeat `guard` runs reuse a cross-process plan cache that is invalidated on any working-tree change | `tests/plan-disk-cache.test.mjs` |
 
 ## Success Criteria
 

--- a/extensions/spec-kit-docguard/commands/guard.md
+++ b/extensions/spec-kit-docguard/commands/guard.md
@@ -1,5 +1,5 @@
 ---
-description: "Run 19-validator quality gate with severity triage and actionable remediation"
+description: "Run the full quality gate with severity triage and actionable remediation"
 handoffs:
   - label: Fix All Issues
     agent: docguard.fix
@@ -43,7 +43,7 @@ npx --yes docguard-cli@latest guard $ARGUMENTS
 
 5. Re-run guard after fixes. Iterate until all checks pass (max 3 iterations).
 
-## Validators (20 total)
+## Validators
 
 | Validator | What It Checks |
 |-----------|---------------|

--- a/extensions/spec-kit-docguard/extension.yml
+++ b/extensions/spec-kit-docguard/extension.yml
@@ -3,7 +3,7 @@ schema_version: "1.0"
 extension:
   id: "docguard"
   name: "DocGuard — CDD Enforcement"
-  version: "0.22.0"
+  version: "0.22.1"
   description: "Canonical-Driven Development enforcement as a true spec-kit extension. LLM-first design with 19 automated validators, 4 AI behavior skills, spec-kit skill chaining, and workflow hooks. Zero NPM runtime dependencies."
   author: "Ricardo Accioly"
   repository: "https://github.com/raccioly/docguard"

--- a/extensions/spec-kit-docguard/skills/docguard-fix/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-fix/SKILL.md
@@ -6,10 +6,10 @@ description: AI-driven documentation repair with structured research workflow, t
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.0
+  version: 0.22.1
   source: extensions/spec-kit-docguard/skills/docguard-fix
 ---
-<!-- docguard:version: 0.22.0 -->
+<!-- docguard:version: 0.22.1 -->
 
 # DocGuard Fix Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-guard/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-guard/SKILL.md
@@ -7,10 +7,10 @@ description: Run DocGuard guard validation against Canonical-Driven Development 
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.0
+  version: 0.22.1
   source: extensions/spec-kit-docguard/skills/docguard-guard
 ---
-<!-- docguard:version: 0.22.0 -->
+<!-- docguard:version: 0.22.1 -->
 
 # DocGuard Guard Skill
 
@@ -24,7 +24,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 ## Goal
 
-Execute DocGuard's 19-validator guard suite against the current project, parse structured results, triage findings by severity and impact, and produce an actionable remediation plan. This skill transforms raw CLI output into an AI-digestible quality assessment.
+Execute DocGuard's full guard validator suite against the current project, parse structured results, triage findings by severity and impact, and produce an actionable remediation plan. This skill transforms raw CLI output into an AI-digestible quality assessment.
 
 ## Pre-Execution Checks
 

--- a/extensions/spec-kit-docguard/skills/docguard-review/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-review/SKILL.md
@@ -6,10 +6,10 @@ description: Cross-document consistency analysis and quality assessment. Perform
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.0
+  version: 0.22.1
   source: extensions/spec-kit-docguard/skills/docguard-review
 ---
-<!-- docguard:version: 0.22.0 -->
+<!-- docguard:version: 0.22.1 -->
 
 # DocGuard Review Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-score/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-score/SKILL.md
@@ -6,10 +6,10 @@ description: CDD maturity assessment with category-aware improvement roadmap. Ru
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.0
+  version: 0.22.1
   source: extensions/spec-kit-docguard/skills/docguard-score
 ---
-<!-- docguard:version: 0.22.0 -->
+<!-- docguard:version: 0.22.1 -->
 
 # DocGuard Score Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-sync/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-sync/SKILL.md
@@ -4,7 +4,7 @@ description: Keep canonical documentation ALWAYS UP TO DATE. Refreshes code-trut
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.0
+  version: 0.22.1
   source: extensions/spec-kit-docguard/skills/docguard-sync
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docguard-cli",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "The enforcement tool for Canonical-Driven Development (CDD). Audit, generate, and guard your project documentation.",
   "type": "module",
   "bin": {

--- a/specs/002-fix-test-discovery/plan.md
+++ b/specs/002-fix-test-discovery/plan.md
@@ -4,12 +4,33 @@
 **Spec**: [spec.md](file:///Users/ricardoaccioly/.gemini/canonical-spec-kit/specs/002-fix-test-discovery/spec.md)  
 **Created**: 2026-03-18
 
+## Summary
+
+Fix three test-file-discovery bugs in the Docs-Diff validator plus the scorer's CI
+detection. `getTestFilesFromPatterns()` misuses the ignore-filter as a *match*
+function, so it pulls test files from `node_modules`; `calcTestingScore()` recognizes
+only two GitHub Actions files. This plan introduces shared glob matching, scopes
+test-file resolution to the project tree, and broadens CI detection — all on shared
+infra (no per-validator duplication), verified by regression tests.
+
 ## Technical Context
 
 - **Runtime**: Node.js 18+ (zero NPM deps)
 - **Test Framework**: `node:test`
 - **Constitution**: v1.1.0 (shared infra allowed per Principle IV)
 - **Affected Area**: Test file resolution in docs-diff validator + scoring CI detection
+
+## Project Structure
+
+```
+cli/
+  validators/docs-diff.mjs   # getTestFilesFromPatterns() — bug 1 & 2 (match vs ignore)
+  commands/score.mjs         # calcTestingScore() — bug 3 (CI detection)
+  shared-glob.mjs            # NEW: shared glob→regex matcher (anchored, node_modules-safe)
+tests/
+  docs-diff.test.mjs         # regression: no node_modules test files
+  score-ci-detection.test.mjs# regression: broader CI provider coverage
+```
 
 ## Root Cause Analysis
 

--- a/tests/npm-pack-smoke.test.mjs
+++ b/tests/npm-pack-smoke.test.mjs
@@ -1,6 +1,8 @@
 /**
  * v0.19-P1 — npm-pack smoke test.
  *
+ * @req NFR-002 — published package runs with zero runtime dependencies on Node ≥18.
+ *
  * Builds the actual tarball that would be published to npm, extracts it
  * into a temp directory, and runs the CLI against a tiny fixture. Catches
  * the class of bugs where a needed file is missing from `package.json`'s

--- a/tests/plan-disk-cache.test.mjs
+++ b/tests/plan-disk-cache.test.mjs
@@ -1,6 +1,8 @@
 /**
  * v0.18-P2 — Cross-process plan cache (.docguard/plan.cache.json).
  *
+ * @req NFR-003 — repeat guard runs reuse a cross-process plan cache, invalidated on tree change.
+ *
  * Verifies the disk cache (L2):
  *   - First call writes the file
  *   - Second call (in a fresh process / fresh in-memory state) reads it

--- a/tests/security-init-injection.test.mjs
+++ b/tests/security-init-injection.test.mjs
@@ -1,6 +1,8 @@
 /**
  * v0.21.1 — Issue #190 regression tests.
  *
+ * @req NFR-001 — CLI subprocess invocations are injection-safe (allowlist + execFileSync).
+ *
  * Pre-v0.21.1, `docguard init` was vulnerable to command injection via the
  * `ai` field in `.specify/init-options.json`:
  *


### PR DESCRIPTION
## v0.22.1 (patch)

Addresses the repo's own `guard` self-audit warnings + verified external field feedback. **Honest fixes only — nothing gamed.** Where "making guard green" would mean date-bumping or papering over a too-strict validator, the fix is deferred to v0.23.0 (validator improvements), not faked.

### Fixed
- **Stale validator counts in scaffolded files** (`SKILL.md` "19-validator", `guard.md` "20 total") that drift every release and ship into user projects → count-free phrasing. *(field Issue 1)*
- **REQUIREMENTS.md NFRs were web-service boilerplate** ("200ms p95", "99.9% uptime") on a zero-dep CLI. Rewrote NFR-001/002/003 to real, test-backed NFRs (injection-safe spawns, zero deps, plan cache) + `@req` traced to their regression tests. Clears 3 Traceability warnings honestly.
- **`specs/002/plan.md`** — added Spec-Kit-mandated Summary + Project Structure (real content).

### Added / Improved
- `docguard explain canonical-sync` (was missing) *(field Issue 10)*
- Test-Spec "no mappings" note now cites the table format + `explain` *(field Issue 4)*

### Docs
- README no longer over-claims language-aware trace mapping for `guard` — the multilingual patterns live in the standalone `trace` command; guard's Traceability validator is JS/TS-first today. *(field Issue 3 honesty fix)*

### Housekeeping
- Untracked a stray `*.tgz` build artifact + gitignored it.

### Deferred to v0.23.0 (the honest "validator is too strict" fixes)
Spec-Kit bugfix-spec conformance (specs 004/005), per-doc-type negation thresholds (field Issue 14), docs-diff test-file convention, language-aware guard Traceability (field Issue 3 full), env-extractor scoping (Issue 7), validator-name normalizer (Issue 12), `--version --verbose` (Issue 11), demo↔docguard import-cycle refactor.

### Gates
- ✅ 632/632 tests pass
- ✅ `docguard guard` exits 0 (25 → 20 warnings; all remaining are deferred/accepted, none introduced here)
- ✅ `sync --write` confirmed freshness warnings are git-age lag, not real drift (left honest, not date-bumped)

🤖 External feedback verified by parallel agents against current code before acting.