### PR TITLE
fix(vscode): command injection via workspace path [SECURITY]

### DIFF
--- a/vscode-extension/extension.js
+++ b/vscode-extension/extension.js
@@ -9,7 +9,7 @@
  */
 
 const vscode = require('vscode');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
@@ -180,17 +180,33 @@ function findSpecguard(workspaceDir) {
 }
 
 function execSpecguard(workspaceDir, args) {
-  const localBin = findSpecguard(workspaceDir);
+  // SECURITY (command injection): never build a shell string from the
+  // workspace path or args. `localBin` embeds `workspaceDir`, which the user
+  // controls by opening a folder — a name like `foo" && rm -rf ~ && echo "`
+  // would inject under the old `execSync(\`"${localBin}" ${args}\`)`. We pass
+  // argv directly to execFileSync (no shell), so the path is argv[0] (a literal
+  // filename) and every arg is a literal token — metacharacters are inert.
+  // Accepts an array (preferred) or a space-separated string (back-compat;
+  // safe because the split tokens are never shell-interpreted).
+  const argv = Array.isArray(args)
+    ? args
+    : String(args).trim().split(/\s+/).filter(Boolean);
 
-  let cmd;
+  const localBin = findSpecguard(workspaceDir);
+  const isWindows = process.platform === 'win32';
+
+  let bin, finalArgs;
   if (localBin) {
-    cmd = `"${localBin}" ${args}`;
+    bin = localBin;
+    finalArgs = argv;
   } else {
-    cmd = `npx -y specguard ${args}`;
+    // `npx` is `npx.cmd` on Windows; execFileSync resolves it via PATHEXT.
+    bin = isWindows ? 'npx.cmd' : 'npx';
+    finalArgs = ['-y', 'specguard', ...argv];
   }
 
   try {
-    return execSync(cmd, {
+    return execFileSync(bin, finalArgs, {
       cwd: workspaceDir,
       encoding: 'utf-8',
       env: { ...process.env, NO_COLOR: '1' },

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "docguard-vscode",
   "displayName": "DocGuard — CDD Compliance",
   "description": "Canonical-Driven Development (CDD) enforcement for VS Code. Inline warnings, CDD score in status bar, and guard commands.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "publisher": "raccioly",
   "icon": "icon.png",
   "repository": {


### PR DESCRIPTION
## Security fix — command injection in the VS Code extension

**Severity:** real, in a **published** extension (`docguard-vscode`, publisher `raccioly`, was 0.4.0).

`execSpecguard` built a shell string and ran it via `execSync`:
```js
cmd = `"${localBin}" ${args}`;   // localBin embeds the workspace path
execSync(cmd, { cwd: workspaceDir, ... });
```
`localBin` = `<workspaceDir>/node_modules/.bin/specguard`. The workspace path is user-controlled (you open the folder), so opening a folder named `foo" && rm -rf ~ && echo "` executed arbitrary commands.

### Fix
Pass argv directly to `execFileSync` — **no shell**. The binary path is `argv[0]` (a literal filename) and each arg a literal token, so metacharacters in the path or args are inert. `execSpecguard` now accepts an **array** (preferred) or a space-separated **string** (back-compat — safe, since split tokens are never shell-interpreted). Windows uses `npx.cmd`.

- `execSync` was used only here → import swapped to `execFileSync`
- Extension bumped 0.4.0 → 0.4.1

### Verification
- `execSpecguard` parses cleanly in isolation (the file's pre-existing top-level-`await` quirk makes whole-file `node --check` noisy — unrelated to this change, present on `main` too)
- Arg-handling verified for both string (`'fix --format prompt'` → `['fix','--format','prompt']`) and array forms
- All 8 call sites pass simple flag strings (no embedded spaces) → unaffected

### Supersedes #205
Same finding from the Sentinel auto-agent; this implementation drops its fragile quoted-arg regex re-parse in favor of plain array passing.

### ⚠️ Publish note
The extension ships via its own `vsce publish` pipeline — merging this lands the fix in the repo, but the **marketplace publish is a separate manual step you'll need to run** (`cd vscode-extension && vsce publish`).

🤖 Verified against current code; fix reviewed for shell-free execution.