### PR TITLE
feat(doc-quality): per-doc negation-load override (field Issue 14)

### DIFF
--- a/cli/validators/doc-quality.mjs
+++ b/cli/validators/doc-quality.mjs
@@ -516,6 +516,21 @@ function getCanonicalDocs(projectDir) {
  * paragraphs are scored. Documents that are mostly tables/code/reference
  * material are skipped for readability (they'd score 0/100 unfairly).
  */
+/**
+ * Parse a per-doc quality-rule override marker, e.g.
+ *   <!-- docguard:quality negation-load off — security doc, prohibitive language is precise -->
+ *   <!-- docguard:quality negation-load 0.35 — operational doc -->
+ * Returns { off: true } | { threshold: <number> } | null. A required reason
+ * after the value is encouraged (and self-documenting) but not enforced here.
+ */
+function parseQualityOverride(content, rule) {
+  const re = new RegExp('<!--\\s*docguard:quality\\s+' + rule + '\\s+(off|\\d*\\.?\\d+)\\b', 'i');
+  const m = content.match(re);
+  if (!m) return null;
+  const v = m[1].toLowerCase();
+  return v === 'off' ? { off: true } : { threshold: parseFloat(v) };
+}
+
 function analyzeDocument(doc) {
   const content = readFileSync(doc.path, 'utf-8');
   const proseText = extractProse(content);
@@ -554,6 +569,7 @@ function analyzeDocument(doc) {
       conditionalLoad: conditional.ratio,
     },
     details: { passive, ambiguous, atomicity, negation, conditional },
+    overrides: { negationLoad: parseQualityOverride(content, 'negation-load') },
   };
 }
 
@@ -650,13 +666,20 @@ export function validateDocQuality(projectDir, config) {
     }
 
     // ── Check 7: Negation Load ──
+    // Per-doc override (security/operational docs legitimately use "never",
+    // "must not", "cannot") and a project-wide config threshold both honored.
     results.total++;
-    if (m.negationLoad <= THRESHOLDS.negationLoad.warn) {
+    const negOv = analysis.overrides?.negationLoad;
+    const negThreshold = negOv?.threshold
+      ?? config.docQuality?.negationLoadThreshold
+      ?? THRESHOLDS.negationLoad.warn;
+    if (negOv?.off || m.negationLoad <= negThreshold) {
       results.passed++;
     } else {
       results.warnings.push(
         `${doc.name}: High negation load (${(m.negationLoad * 100).toFixed(0)}% of sentences use negation). ` +
-        `Rephrase in positive terms: "must not fail" → "must succeed" (IEEE 830 §4.3)`
+        `Rephrase in positive terms: "must not fail" → "must succeed" (IEEE 830 §4.3). ` +
+        `If the negation is intentional, add: <!-- docguard:quality negation-load off — your reason -->`
       );
     }
 

--- a/docs-canonical/CI-RECIPES.md
+++ b/docs-canonical/CI-RECIPES.md
@@ -1,5 +1,7 @@
 # CI Recipes
 
+<!-- docguard:quality negation-load off — operational doc: "read-only, never modifies your repo", "fork PRs won't run", "don't commit X" are precise prohibitions; positive rephrasing would reduce clarity -->
+
 <!-- docguard:section id=overview source=human -->
 This document covers the GitHub Action and CI integration patterns DocGuard ships.
 Each recipe is a copy-pasteable workflow you can drop into `.github/workflows/`.

--- a/docs-canonical/SURFACE-AUDIT.md
+++ b/docs-canonical/SURFACE-AUDIT.md
@@ -1,5 +1,7 @@
 # DocGuard Surface Audit
 
+<!-- docguard:quality negation-load off — analytical audit doc: findings are inherently stated as "guard cannot catch X", "names don't telegraph Y"; these negations are the substance, not sloppy phrasing -->
+
 > **Status:** Survey only — recommendations, no code changes.
 > **Owner:** Ricardo Accioly · **Date:** 2026-05-26 · **DocGuard:** v0.18.1 (v0.19.0 staged but unpushed)
 > **Scope:** Every command, every validator, every doc claim about either. The question: did 15 releases of additive work leave us with too many similar verbs for users to learn, and where is the doc-vs-code drift that `guard` can't see today?

--- a/tests/doc-quality.test.mjs
+++ b/tests/doc-quality.test.mjs
@@ -90,4 +90,45 @@ The manager approves the budget. The customer buys the product.
     assert.strictEqual(result.passed, result.total);
     assert.ok(result.total > 0);
   });
+
+  const NEGATION_HEAVY = `
+# Operational Notes
+
+The runner does not modify the repo and never writes to disk anywhere.
+It cannot escalate privileges and will not bypass the quality gate.
+Do not commit secrets here. The token is not stored and is not logged.
+Forks will not run the workflow, and stale branches are not refreshed.
+The cache is not shared and does not persist between separate jobs.
+`.trim();
+
+  it('honors the per-doc negation-load override marker', () => {
+    mkdirSync(join(tmpDir, 'docs-canonical'), { recursive: true });
+    const p = join(tmpDir, 'docs-canonical', 'OPS.md');
+
+    // Without the marker → a negation-load warning fires.
+    writeFileSync(p, NEGATION_HEAVY);
+    const before = validateDocQuality(tmpDir, {});
+    assert.ok(
+      before.warnings.some(w => /negation load/i.test(w)),
+      'expected a negation-load warning without the marker'
+    );
+
+    // With the marker → the negation check passes (no negation warning).
+    writeFileSync(p, '<!-- docguard:quality negation-load off — operational doc -->\n' + NEGATION_HEAVY);
+    const after = validateDocQuality(tmpDir, {});
+    assert.strictEqual(
+      after.warnings.filter(w => /negation load/i.test(w)).length, 0,
+      'the override marker should suppress the negation-load warning'
+    );
+  });
+
+  it('honors a config-level negationLoadThreshold', () => {
+    mkdirSync(join(tmpDir, 'docs-canonical'), { recursive: true });
+    writeFileSync(join(tmpDir, 'docs-canonical', 'OPS.md'), NEGATION_HEAVY);
+    const result = validateDocQuality(tmpDir, { docQuality: { negationLoadThreshold: 1.0 } });
+    assert.strictEqual(
+      result.warnings.filter(w => /negation load/i.test(w)).length, 0,
+      'a 1.0 threshold should never warn on negation'
+    );
+  });
 });


### PR DESCRIPTION
Field-report **Issue 14**: the negation-load check was a flat global 0.20 with no override, so security/operational/audit docs that legitimately use "never", "must not", "cannot" got flagged with no honest way to pass.

**Fix:**
- Per-doc marker `<!-- docguard:quality negation-load off — reason -->` (or a numeric threshold), mirroring the sanctioned `docguard:section … n/a — reason` pattern.
- Config knob `docQuality.negationLoadThreshold`.
- Warning text now points to the override.

Applied with genuine reasons to `CI-RECIPES.md` (operational: "read-only, never modifies your repo") and `SURFACE-AUDIT.md` (analytical: "guard cannot catch X"). Honest — the negation is the substance, not sloppy phrasing.

**Validation:** 634/634 tests (+2: marker suppression + config threshold); Doc-Quality 54/56 → 56/56; warnings 19 → 17. No version bump (staged for v0.23.0).