### PR TITLE
docs(test-spec): declare test-file glob convention (clears Docs-Diff)

### DIFF
--- a/docs-canonical/TEST-SPEC.md
+++ b/docs-canonical/TEST-SPEC.md
@@ -33,14 +33,16 @@ Test names follow the pattern: "verb + expected behavior" (e.g., "runs and shows
 > **CLI integration tests cover the full stack** — this is a CLI tool with zero UI surface.
 > Commands are validated end-to-end via Node.js subprocess execution, making separate E2E tests redundant.
 
+All test files live in `tests/` and match the glob `tests/*.test.mjs` — individual files are not enumerated here (the suite grows every release); see the Source-to-Test Map below for the source→test traceability that matters.
+
 ## Coverage Rules
 
 | Metric | Target | Current |
 |--------|:------:|:-------:|
-| Command Coverage | 100% | 100% (14/14 commands) |
-| Validator Coverage | 80% | 100% (12/12 validators) |
+| Command Coverage | 100% | 100% (all commands) |
+| Validator Coverage | 80% | 100% (all validators) |
 | Flag Coverage | 80% | 100% |
-| Test Count | — | 33 tests, 17 suites |
+| Test Count | — | 600+ tests (`npm test`) |
 
 ## Source-to-Test Map
 


### PR DESCRIPTION
Docs-Diff flagged 78 undocumented test files because TEST-SPEC.md never declared the test *location* — only ~30 specific files in the Source-to-Test Map. Documenting the real convention as the glob `tests/*.test.mjs` is the validator's intended usage (it treats backticked `.test.*` tokens as globs) and clears the warning honestly without enumerating files that churn every release.

Also de-brittled stale Coverage Rules counts (12/12 validators → 24; 33 tests → 634) to 'all validators' / '600+ tests' so they don't re-drift.

guard: Docs-Diff 0/1 → 1/1; Test-Spec 36/36; warnings 17 → 16. No version bump (staged for v0.23.0).