### PR TITLE
feat(spec-kit): bugfix/lightweight spec type

### DIFF
--- a/cli/scanners/speckit.mjs
+++ b/cli/scanners/speckit.mjs
@@ -221,6 +221,20 @@ function validateSpecQuality(specPath) {
   const issues = [];
   const content = readFileSync(specPath, 'utf-8');
 
+  // Bugfix / lightweight specs document a defect (symptom → root cause → fix),
+  // not a feature (User Scenarios / Requirements / Success Criteria with FR/SC
+  // IDs). The full feature template doesn't fit them — forcing it produces
+  // ceremony, not clarity. Opt in with `<!-- docguard:spec-type bugfix -->`
+  // and we validate the bugfix-appropriate shape instead: the spec must still
+  // state a Root Cause and a Fix, so it's a narrower check, not a free pass.
+  if (/<!--\s*docguard:spec-type\s+(?:bugfix|lightweight|patch)\b/i.test(content)) {
+    const { missing } = checkSections(content, ['Root Cause', 'Fix']);
+    for (const section of missing) {
+      issues.push(`Bugfix spec missing "${section}" — a defect spec must state its root cause and fix`);
+    }
+    return issues;
+  }
+
   // Check mandatory sections
   const { missing } = checkSections(content, SPEC_MANDATORY_SECTIONS);
   for (const section of missing) {

--- a/specs/004-v020-env-var-false-negative/spec.md
+++ b/specs/004-v020-env-var-false-negative/spec.md
@@ -1,5 +1,7 @@
 # Feature Specification: Fix Env-Var Detector False Negative & Accuracy Terminology
 
+<!-- docguard:spec-type bugfix — defect spec (symptom → root cause → fix); not held to the feature-spec template -->
+
 **Feature Branch**: `004-v020-env-var-false-negative`  
 **Created**: 2026-05-26  
 **Status**: Draft  

--- a/specs/005-hugocross-next-bugs/spec.md
+++ b/specs/005-hugocross-next-bugs/spec.md
@@ -1,5 +1,7 @@
 # Feature Specification: Fix 6 Confirmed Bugs from HugoCross Next.js Field Test
 
+<!-- docguard:spec-type bugfix — defect spec (symptom → root cause → fix); not held to the feature-spec template -->
+
 **Feature Branch**: `005-hugocross-next-bugs`  
 **Created**: 2026-05-26  
 **Status**: Draft  

--- a/tests/speckit-bugfix.test.mjs
+++ b/tests/speckit-bugfix.test.mjs
@@ -1,0 +1,72 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { validateSpecKitIntegration } from '../cli/scanners/speckit.mjs';
+
+describe('Spec-Kit — bugfix spec type', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'docguard-speckit-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeSpec(name, body) {
+    const dir = join(tmpDir, 'specs', name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'spec.md'), body);
+  }
+
+  const warnsFor = (results, name) =>
+    results.warnings.filter(w => w.includes(`${name}/spec.md`));
+
+  it('exempts a bugfix spec from the feature template when it states root cause + fix', () => {
+    writeSpec('001-defect', [
+      '# Defect: env-var detector false negative',
+      '<!-- docguard:spec-type bugfix -->',
+      '## Root Cause',
+      'The scanner only matched backticked names.',
+      '## Fix',
+      'Also extract pipe-table rows.',
+    ].join('\n\n'));
+
+    const r = validateSpecKitIntegration(tmpDir, {});
+    assert.deepEqual(
+      warnsFor(r, '001-defect'), [],
+      'a bugfix spec with Root Cause + Fix should not be flagged for feature-template sections'
+    );
+  });
+
+  it('still requires root cause + fix in a bugfix spec (not a free pass)', () => {
+    writeSpec('002-thin', [
+      '# Defect report',                 // no "Root Cause"/"Fix" in the title
+      '<!-- docguard:spec-type bugfix -->',
+      'Some prose that never states a root cause or a fix.',
+    ].join('\n\n'));
+
+    const r = validateSpecKitIntegration(tmpDir, {});
+    const w = warnsFor(r, '002-thin');
+    assert.ok(w.some(x => /Root Cause/i.test(x)), 'expected a missing Root Cause warning');
+    assert.ok(w.some(x => /\bFix\b/i.test(x)), 'expected a missing Fix warning');
+  });
+
+  it('holds a normal feature spec to the full template', () => {
+    writeSpec('003-feature', [
+      '# Feature: shiny new thing',
+      'A description with none of the mandatory feature sections.',
+    ].join('\n\n'));
+
+    const r = validateSpecKitIntegration(tmpDir, {});
+    const w = warnsFor(r, '003-feature');
+    assert.ok(
+      w.some(x => /Missing mandatory section/.test(x)),
+      'a feature spec (no bugfix marker) must still be held to the spec template'
+    );
+  });
+});


### PR DESCRIPTION
The Spec-Kit validator held every spec to the full feature template (User Scenarios + Requirements + Success Criteria + FR/SC IDs). Bugfix specs document a defect (symptom → root cause → fix), not a feature — and adding FR/SC IDs to them collides with the global `@req` namespace the Traceability validator scans.

**New:** opt-in marker `<!-- docguard:spec-type bugfix -->` (also `lightweight`/`patch`). A flagged spec is validated for the bugfix shape instead — it **must still state a Root Cause and a Fix**, so it's a narrower check, not a free pass. Marked the repo's own specs/004 + specs/005.

**Validation:** +3 tests (exemption / still-warns-when-thin / feature specs still held); 637/637 pass; Spec-Kit 11/13 → 13/13; warnings **16 → 6** (remaining 6 = freshness git-age). No version bump (staged for v0.23.0).