### PR TITLE
docs: genuine freshness review + refresh (clears all 6 freshness warnings)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # DocGuard Roadmap
 
-<!-- docguard:version 0.4.0 -->
+<!-- docguard:version 0.5.0 -->
 <!-- docguard:status living -->
-<!-- docguard:last-reviewed 2026-05-26 -->
+<!-- docguard:last-reviewed 2026-05-29 -->
 <!-- docguard:owner @raccioly -->
 
 > The planned evolution of DocGuard and Canonical-Driven Development (CDD).
@@ -10,8 +10,8 @@
 | Metadata | Value |
 |----------|-------|
 | **Status** | ![Status](https://img.shields.io/badge/status-active-brightgreen) |
-| **Version** | `0.4.0` |
-| **Last Updated** | 2026-03-12 |
+| **Version** | `0.5.0` |
+| **Last Updated** | 2026-05-29 |
 | **Owner** | [@raccioly](https://github.com/raccioly) |
 
 ---
@@ -31,7 +31,19 @@ Make **Canonical-Driven Development** the industry standard for AI-age software 
 | 2 | Polish & Adoption | ✅ Complete | Mar 2026 |
 | 3 | AI Generate Mode | ✅ Complete | Mar 2026 |
 | 4 | Integrations | ✅ Complete | Mar 2026 |
+| 4.5 | Continuous Hardening | 🔄 Ongoing | Mar–May 2026 |
 | 5 | Dashboard (SaaS) | 💭 Future | Q4 2026 |
+
+### Phase 4.5: Continuous Hardening (v0.11 → v0.23) 🔄
+
+Sustained, feedback-driven maturation since the March milestones:
+
+- **Validators grew 9 → 24** — added Canonical-Sync, Surface-Sync, Metrics-Consistency, Doc-Quality, Traceability, Cross-Reference, Generated-Staleness, and more.
+- **Language-aware** test/trace discovery (Python, Go, Rust, Java/Kotlin, Ruby, PHP) shared between `docguard trace` and the guard-time Traceability validator.
+- **Per-doc/per-rule overrides** — `docguard:section … n/a`, `docguard:quality negation-load off`, `docguard:spec-type bugfix` — so the validators fit real projects instead of forcing ceremony.
+- **Security** — closed command-injection vectors in CLI `init` (#190) and the VS Code extension (#207); subprocesses now use `execFileSync` + allowlist validation.
+- **Published the VS Code extension** (`DocGuard.docguard-vscode`) to the Marketplace.
+- **Distribution** — npm + PyPI + GitHub Action + Spec Kit community-catalog auto-sync.
 
 ---
 

--- a/docs-canonical/ARCHITECTURE.md
+++ b/docs-canonical/ARCHITECTURE.md
@@ -1,15 +1,15 @@
 # Architecture
 
-<!-- docguard:version 0.4.0 -->
+<!-- docguard:version 0.5.0 -->
 <!-- docguard:status active -->
-<!-- docguard:last-reviewed 2026-03-13 -->
+<!-- docguard:last-reviewed 2026-05-29 -->
 
 | Metadata | Value |
 |----------|-------|
 | **Status** | ![Status](https://img.shields.io/badge/status-active-brightgreen) |
-| **Version** | `0.4.0` |
-| **Last Updated** | 2026-03-13 |
-| **Project Size** | 30+ files, ~6K lines |
+| **Version** | `0.5.0` |
+| **Last Updated** | 2026-05-29 |
+| **Project Size** | ~24K lines across `cli/` |
 
 ---
 
@@ -24,11 +24,12 @@ It targets development teams and AI coding agents that need to maintain document
 | Component | Responsibility | Location | Key Files |
 |-----------|---------------|----------|-----------|
 | **CLI Entry Point** | Argument parsing, config loading, command routing | `cli/` | `docguard.mjs` |
-| **Commands** | 15 user-facing commands (diagnose, guard, init, score, fix, generate, diff, agents, trace, ci, watch, hooks, badge, llms, publish) | `cli/commands/` | `*.mjs` |
-| **Validators** | 18 independent validation modules that check specific aspects of CDD compliance | `cli/validators/` | `*.mjs` |
-| **Scanners** | 10 project file scanners for test discovery, route detection, schema mapping, CDK/IaC, doc-tools, integrations, frontend surface, memory-plan | `cli/scanners/` | `*.mjs` |
+| **Commands** | User-facing commands (the Daily 5 — init/guard/diff/sync/score — plus situational tools: diagnose, fix, generate, trace, explain, memory, upgrade, watch, demo, and `init --with` scaffolders) | `cli/commands/` | `*.mjs` |
+| **Validators** | 24 independent validation modules that check specific aspects of CDD compliance | `cli/validators/` | `*.mjs` |
+| **Scanners** | 11 project file scanners for test discovery, route detection, schema mapping, CDK/IaC, doc-tools, integrations, frontend surface, spec-kit, memory-plan | `cli/scanners/` | `*.mjs` |
 | **Writers** | Deterministic doc-mutation modules — section-addressable edits, mechanical fix registry, API-Reference writer (no LLM) | `cli/writers/` | `mechanical.mjs`, `sections.mjs`, `api-reference.mjs` |
-| **Shared** | Cross-cutting utilities — `DEFAULT_IGNORE_DIRS`, glob match/ignore filters, monorepo source-root resolution | `cli/` | `shared-ignore.mjs`, `shared-source.mjs`, `shared.mjs` |
+| **Config** | Configuration loading — defaults, `.docguard.json` merge, profile presets, project-type detection (extracted from the entry point to keep the import graph acyclic) | `cli/` | `config.mjs` |
+| **Shared** | Cross-cutting utilities — ignore/glob filters, source-root resolution, git helpers, and the shared doc→code trace patterns used by both `trace` and the Traceability validator | `cli/` | `shared-ignore.mjs`, `shared-source.mjs`, `shared-git.mjs`, `shared-trace-patterns.mjs`, `shared.mjs` |
 | **Templates** | Document skeletons (ARCHITECTURE, SECURITY, etc.) and slash command files for AI agents | `templates/` | `*.template`, `commands/*.md` |
 | **Extension** | Spec Kit extension with 5 AI skills, 4 bash scripts, workflow hooks | `extensions/spec-kit-docguard/` | `skills/*/SKILL.md`, `scripts/bash/*.sh` |
 | **VS Code Extension** | Status bar score, inline diagnostics, Code Actions, file watchers | `vscode-extension/` | `extension.js`, `package.json` |
@@ -67,8 +68,9 @@ The architecture follows a strict 4-layer model where each layer can only import
 | **Validators** (`cli/validators/`) | Independent validation modules | Scanners, Shared utilities, Node.js built-ins | Cannot import from Commands or Writers |
 | **Scanners** (`cli/scanners/`) | Project intelligence — detect routes, schemas, IaC, frontend surface | Shared utilities, Node.js built-ins | Cannot import from Validators, Commands, Writers |
 | **Writers** (`cli/writers/`) | Mutate canonical docs surgically (section-addressable, no LLM) | Node.js built-ins only | Cannot import from Validators, Scanners, Commands |
-| **Shared** (`cli/shared-*.mjs`) | Cross-cutting utilities: `DEFAULT_IGNORE_DIRS`, glob match, source-root resolution | Node.js built-ins only | Cannot import from any other layer |
-| **Entry Point** (`cli/docguard.mjs`) | Config loading, ANSI colors, argument parsing, command dispatch | Commands (imports all command modules) | Calls validators only through commands |
+| **Shared** (`cli/shared-*.mjs`) | Cross-cutting utilities: ignore/glob filters, source-root resolution, git helpers, shared trace patterns | Node.js built-ins only | Cannot import from any other layer |
+| **Config** (`cli/config.mjs`) | `loadConfig` + defaults/profile merge + project-type detection | Shared utilities, Node.js built-ins | Cannot import from Commands (extracted so `demo`→`docguard` is no longer a cycle) |
+| **Entry Point** (`cli/docguard.mjs`) | ANSI colors, argument parsing, command dispatch, banner/help | Commands, Config (`loadConfig`) | Calls validators only through commands |
 
 **Key Rule**: Validators are pure functions. They receive `projectDir` and `config`, then return results. They stay isolated from commands and the CLI entry point. The Extension layer operates independently, using the CLI as an external tool.
 
@@ -180,5 +182,6 @@ DocGuard has **zero runtime dependencies**. All functionality uses Node.js built
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
+| 0.5.0 | 2026-05-29 | DocGuard Team | Refresh for v0.22–v0.23: 24 validators, 11 scanners, new `config.mjs` (config extracted to break the demo↔docguard cycle) and `shared-trace-patterns.mjs` (shared multilingual trace patterns) |
 | 0.4.0 | 2026-03-13 | DocGuard Team | Complete rewrite with real project data, AI orchestration architecture |
 | 0.1.0 | 2026-03-13 | DocGuard Generate | Auto-generated skeleton |

--- a/docs-canonical/DATA-MODEL.md
+++ b/docs-canonical/DATA-MODEL.md
@@ -2,7 +2,7 @@
 
 <!-- docguard:version 0.4.0 -->
 <!-- docguard:status active -->
-<!-- docguard:last-reviewed 2026-05-26 -->
+<!-- docguard:last-reviewed 2026-05-29 -->
 
 | Metadata | Value |
 |----------|-------|

--- a/docs-canonical/ENVIRONMENT.md
+++ b/docs-canonical/ENVIRONMENT.md
@@ -2,7 +2,7 @@
 
 <!-- docguard:version 0.5.0 -->
 <!-- docguard:status active -->
-<!-- docguard:last-reviewed 2026-05-26 -->
+<!-- docguard:last-reviewed 2026-05-29 -->
 
 > DocGuard is a zero-dependency CLI tool. No environment variables needed.
 

--- a/docs-canonical/SECURITY.md
+++ b/docs-canonical/SECURITY.md
@@ -1,8 +1,10 @@
 # Security
 
-<!-- docguard:version 0.4.0 -->
+<!-- docguard:quality negation-load off — security doc: prohibitive phrasing ("never a shell string", "can't inject", "no dependencies") is precise and intentional, not sloppy writing -->
+
+<!-- docguard:version 0.5.0 -->
 <!-- docguard:status active -->
-<!-- docguard:last-reviewed 2026-05-26 -->
+<!-- docguard:last-reviewed 2026-05-29 -->
 
 | Metadata | Value |
 |----------|-------|
@@ -52,8 +54,8 @@ DocGuard uses a simple permission model: it inherits filesystem permissions from
 |----------|---------|-----------|
 | **File reads** | Project files within `projectDir` | DocGuard only reads files within the project directory and its own templates |
 | **File writes** | `docguard init`, `docguard generate`, `docguard hooks` | Only writes to `docs-canonical/`, root docs, `.docguard.json`, `.git/hooks/` |
-| **Child processes** | `git log`, `git diff` (freshness validator) | Only executes `git` commands with safe, read-only flags |
-| **User input** | CLI arguments parsed by the entry point | All input is sanitized before use in child processes |
+| **Child processes** | `git log`/`git diff` (freshness), `specify init` (Spec Kit scaffolding), `specguard` (VS Code extension) | All spawned via `execFileSync` with an argv array — never a shell string. The binary is `argv[0]` (a literal filename) and each arg a literal token, so workspace paths and config values can't inject commands |
+| **User input** | CLI arguments parsed by the entry point | Agent/path inputs that reach a subprocess are allowlist-validated (`/^[a-zA-Z0-9_-]{1,32}$/`) before use |
 
 ## Command Safety Levels
 
@@ -96,7 +98,7 @@ DocGuard's own `.gitignore` excludes:
 - [x] `.env` files are excluded from version control
 - [x] All secrets are environment-variable-based
 - [x] CLI operates 100% offline
-- [x] All user input is sanitized before `exec()`
+- [x] Subprocesses use `execFileSync` (argv arrays, no shell); injection-prone inputs are allowlist-validated (closed #190 in CLI init, #205/#207 in the VS Code extension)
 - [x] File writes are opt-in only (init, generate, hooks commands)
 - [x] Git commands are read-only (`git log`, `git diff`)
 - [x] Zero npm dependencies eliminates supply chain risk

--- a/docs-canonical/TEST-SPEC.md
+++ b/docs-canonical/TEST-SPEC.md
@@ -2,7 +2,7 @@
 
 <!-- docguard:version 0.7.0 -->
 <!-- docguard:status active -->
-<!-- docguard:last-reviewed 2026-05-26 -->
+<!-- docguard:last-reviewed 2026-05-29 -->
 
 > DocGuard is a zero-dependency CLI tool. CLI integration tests cover the full stack.
 


### PR DESCRIPTION
Cleared the 6 Freshness warnings **honestly** — actually reviewing + refreshing real drift, not date-stamping.

- **ARCHITECTURE.md** — real refresh: 18→24 validators, 10→11 scanners, new `config.mjs` + `shared-trace-patterns.mjs` in the component map & layer boundaries, Entry Point no longer loads config, size 6K→~24K lines.
- **SECURITY.md** — documented the actual subprocess-safety posture (`execFileSync` + allowlist; the #190/#207 injection fixes); added the negation-load override (security docs are exactly Issue 14's case).
- **ROADMAP.md** — added Phase 4.5 'Continuous Hardening (v0.11→v0.23)'.
- **TEST-SPEC / DATA-MODEL / ENVIRONMENT** — reviewed, confirmed current, stamped.

guard: Freshness 2/8 → **8/8**; my warnings **6 → 0**. Only remaining guard warning is `.jules-setup.sh` (a parallel session's untracked file). 638/638 tests. No version bump (staged for v0.23.0).