### PR TITLE
release: v0.23.0 — validator hardening

### DIFF
--- a/.agent/skills/docguard-fix/SKILL.md
+++ b/.agent/skills/docguard-fix/SKILL.md
@@ -6,10 +6,10 @@ description: AI-driven documentation repair with structured research workflow, t
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.1
+  version: 0.23.0
   source: extensions/spec-kit-docguard/skills/docguard-fix
 ---
-<!-- docguard:version: 0.22.1 -->
+<!-- docguard:version: 0.23.0 -->
 
 # DocGuard Fix Skill
 

--- a/.agent/skills/docguard-guard/SKILL.md
+++ b/.agent/skills/docguard-guard/SKILL.md
@@ -7,10 +7,10 @@ description: Run DocGuard guard validation against Canonical-Driven Development 
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.1
+  version: 0.23.0
   source: extensions/spec-kit-docguard/skills/docguard-guard
 ---
-<!-- docguard:version: 0.22.1 -->
+<!-- docguard:version: 0.23.0 -->
 
 # DocGuard Guard Skill
 

--- a/.agent/skills/docguard-review/SKILL.md
+++ b/.agent/skills/docguard-review/SKILL.md
@@ -6,10 +6,10 @@ description: Cross-document consistency analysis and quality assessment. Perform
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.1
+  version: 0.23.0
   source: extensions/spec-kit-docguard/skills/docguard-review
 ---
-<!-- docguard:version: 0.22.1 -->
+<!-- docguard:version: 0.23.0 -->
 
 # DocGuard Review Skill
 

--- a/.agent/skills/docguard-score/SKILL.md
+++ b/.agent/skills/docguard-score/SKILL.md
@@ -6,10 +6,10 @@ description: CDD maturity assessment with category-aware improvement roadmap. Ru
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.1
+  version: 0.23.0
   source: extensions/spec-kit-docguard/skills/docguard-score
 ---
-<!-- docguard:version: 0.22.1 -->
+<!-- docguard:version: 0.23.0 -->
 
 # DocGuard Score Skill
 

--- a/.agent/skills/docguard-sync/SKILL.md
+++ b/.agent/skills/docguard-sync/SKILL.md
@@ -4,7 +4,7 @@ description: Keep canonical documentation ALWAYS UP TO DATE. Refreshes code-trut
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.1
+  version: 0.23.0
   source: extensions/spec-kit-docguard/skills/docguard-sync
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-05-29
+
+Validator-hardening minor release, driven by external field feedback and a full
+self-audit. Theme: make the validators **fit real projects** and **tell the
+truth**, rather than forcing ceremony or over-claiming. Honest fixes only — no
+doc-gaming. Self-audit guard warnings went 20 → 0-of-ours (the only remaining
+warning is a parallel session's untracked file).
+
+### Added
+- **Language-aware guard Traceability** (field Issue 3) — the guard-time
+  Traceability validator now understands Python, Go, Rust, Java/Kotlin, Ruby,
+  and PHP layouts, not just JS/TS. The multilingual `TEST_PATTERNS` + `TRACE_MAP`
+  live in one shared module (`cli/shared-trace-patterns.mjs`) consumed by both
+  `docguard trace` and the validator, so they can't drift apart. (The README
+  previously claimed this but only the standalone `trace` command delivered it.)
+- **Per-doc negation-load override** (field Issue 14) — `<!-- docguard:quality
+  negation-load off — reason -->` (or a numeric threshold), plus a project-wide
+  `docQuality.negationLoadThreshold` config. Security/operational/audit docs
+  legitimately use "never"/"must not"/"cannot"; this stops false flags without
+  weakening the check for tutorials.
+- **Bugfix/lightweight spec type** — `<!-- docguard:spec-type bugfix -->` makes
+  the Spec-Kit validator check a defect spec for Root Cause + Fix instead of the
+  full feature template (User Scenarios + FR/SC IDs). Narrower check, not a free
+  pass.
+- **`docguard explain canonical-sync`** — the count-level companion validator
+  was missing from the explainer (field Issue 10).
+
+### Changed
+- **`loadConfig` extracted to `cli/config.mjs`** — breaks the demo↔docguard
+  import cycle the Architecture validator flagged (byte-for-byte move, no logic
+  change). New modules import config from there, not the CLI entry point.
+- **Docs-Diff** test-file drift now recognises the documented glob convention
+  (`tests/*.test.mjs`) instead of demanding every test file be enumerated.
+- **Diff loops pre-compile their regexes** (community PR) — O(N·M) → O(N) on the
+  test-file comparison.
+- **Test-Spec** "no mappings" note now points to the expected table format and
+  `docguard explain` (field Issue 4).
+- **Canonical docs refreshed** — ARCHITECTURE (config.mjs, 24 validators, 11
+  scanners, shared-trace-patterns), SECURITY (real `execFileSync`+allowlist
+  subprocess posture), ROADMAP (Phase 4.5 hardening). Genuine review, not
+  date-stamping.
+
+### Related (shipped separately)
+- VS Code extension `DocGuard.docguard-vscode` published to the Marketplace
+  (v0.4.1), including a command-injection fix in `execSpecguard` (#207).
+
 ## [0.22.1] - 2026-05-29
 
 Self-audit + field-feedback patch. Honest fixes only — no doc-gaming. The

--- a/extensions/spec-kit-docguard/extension.yml
+++ b/extensions/spec-kit-docguard/extension.yml
@@ -3,7 +3,7 @@ schema_version: "1.0"
 extension:
   id: "docguard"
   name: "DocGuard — CDD Enforcement"
-  version: "0.22.1"
+  version: "0.23.0"
   description: "Canonical-Driven Development enforcement as a true spec-kit extension. LLM-first design with 19 automated validators, 4 AI behavior skills, spec-kit skill chaining, and workflow hooks. Zero NPM runtime dependencies."
   author: "Ricardo Accioly"
   repository: "https://github.com/raccioly/docguard"

--- a/extensions/spec-kit-docguard/skills/docguard-fix/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-fix/SKILL.md
@@ -6,10 +6,10 @@ description: AI-driven documentation repair with structured research workflow, t
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.1
+  version: 0.23.0
   source: extensions/spec-kit-docguard/skills/docguard-fix
 ---
-<!-- docguard:version: 0.22.1 -->
+<!-- docguard:version: 0.23.0 -->
 
 # DocGuard Fix Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-guard/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-guard/SKILL.md
@@ -7,10 +7,10 @@ description: Run DocGuard guard validation against Canonical-Driven Development 
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.1
+  version: 0.23.0
   source: extensions/spec-kit-docguard/skills/docguard-guard
 ---
-<!-- docguard:version: 0.22.1 -->
+<!-- docguard:version: 0.23.0 -->
 
 # DocGuard Guard Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-review/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-review/SKILL.md
@@ -6,10 +6,10 @@ description: Cross-document consistency analysis and quality assessment. Perform
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.1
+  version: 0.23.0
   source: extensions/spec-kit-docguard/skills/docguard-review
 ---
-<!-- docguard:version: 0.22.1 -->
+<!-- docguard:version: 0.23.0 -->
 
 # DocGuard Review Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-score/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-score/SKILL.md
@@ -6,10 +6,10 @@ description: CDD maturity assessment with category-aware improvement roadmap. Ru
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.1
+  version: 0.23.0
   source: extensions/spec-kit-docguard/skills/docguard-score
 ---
-<!-- docguard:version: 0.22.1 -->
+<!-- docguard:version: 0.23.0 -->
 
 # DocGuard Score Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-sync/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-sync/SKILL.md
@@ -4,7 +4,7 @@ description: Keep canonical documentation ALWAYS UP TO DATE. Refreshes code-trut
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.22.1
+  version: 0.23.0
   source: extensions/spec-kit-docguard/skills/docguard-sync
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docguard-cli",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "description": "The enforcement tool for Canonical-Driven Development (CDD). Audit, generate, and guard your project documentation.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Minor release from a full self-audit + external field feedback. **Honest fixes only** — guard self-audit went **20 warnings → 0 of ours**.

**Headline:** language-aware guard Traceability (field Issue 3) — the README's "language-aware" claim is now true for the default `guard` path, not just `trace`.

**Also:** per-doc negation-load override (Issue 14), bugfix/lightweight spec type, `config.mjs` extraction (broke the demo↔docguard import cycle), Docs-Diff glob convention, diff-loop regex precompile, and a genuine refresh of all 6 canonical docs (ARCHITECTURE/SECURITY/ROADMAP content + the rest reviewed).

Full notes in CHANGELOG `[0.23.0]`.

**Gates:** 638/638 tests · `docguard guard` exits 0 (the single remaining warning is a parallel session's untracked `.jules-setup.sh`, not ours).

Merging bumps `package.json` 0.22.1→0.23.0 → fires the release pipeline (tag, GitHub release, npm, PyPI, Spec Kit catalog sync).