### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 ## 2024-05-24 - Pre-compile RegExp in nested loops
 **Learning:** Instantiating `new RegExp()` inside nested array methods like `.filter` and `.some` creates a severe O(N*M) performance bottleneck, especially when matching two large lists (e.g., documented tests vs. actual test files).
 **Action:** Always pre-compile regular expressions and derived strings into an array of "matcher" objects outside of the loop before iterating, which shifts the instantiation cost from O(N*M) to O(N).
+## 2024-05-31 - [Array comparison in nested loops]
+**Learning:** Comparing two large lists using nested array methods like `.filter` and `.some` with inline string processing (e.g., `basename()`) creates severe O(N*M) bottlenecks.
+**Action:** When comparing arrays, pre-compute expensive string operations into object representations before the loop, and collapse multiple nested `.filter`/`.some` passes into a single iteration block to minimize redundant processing and array allocations.

--- a/cli/commands/diff.mjs
+++ b/cli/commands/diff.mjs
@@ -349,7 +349,8 @@ function diffTests(dir, config = {}) {
   const codeArr = [...codeTests];
 
   // PERFORMANCE OPTIMIZATION: Pre-compile regular expressions to avoid O(N*M)
-  // instantiation bottlenecks inside the nested .filter and .some loops below.
+  // instantiation bottlenecks. Pre-compute basename() to avoid O(N*M) string processing.
+  // Collapse nested filter/some loops into a single iteration block to reduce array allocations.
   const docMatchers = [...docTests].map(docEntry => {
     const entry = String(docEntry).trim();
     const hasSlash = entry.includes('/');
@@ -363,17 +364,41 @@ function diffTests(dir, config = {}) {
     };
   });
 
-  const matches = (matcher, codeRel) => {
-    const subject = matcher.hasSlash ? codeRel : basename(codeRel);
-    return matcher.rx.test(subject);
-  };
+  const codeArrProcessed = codeArr.map(c => ({
+    original: c,
+    basename: basename(c)
+  }));
+
+  const onlyInDocs = [];
+  const matched = [];
+  const codeMatched = new Set();
+
+  for (const m of docMatchers) {
+    let mMatched = false;
+    for (const c of codeArrProcessed) {
+      const subject = m.hasSlash ? c.original : c.basename;
+      if (m.rx.test(subject)) {
+        mMatched = true;
+        codeMatched.add(c.original);
+      }
+    }
+    if (mMatched) {
+      matched.push(m.original);
+    } else {
+      onlyInDocs.push(m.original);
+    }
+  }
+
+  const onlyInCode = codeArrProcessed
+    .filter(c => !codeMatched.has(c.original))
+    .map(c => c.original);
 
   return {
     title: 'Test Files',
     icon: '🧪',
-    onlyInDocs: docMatchers.filter(m => !codeArr.some(c => matches(m, c))).map(m => m.original),
-    onlyInCode: codeArr.filter(c => !docMatchers.some(m => matches(m, c))),
-    matched: docMatchers.filter(m => codeArr.some(c => matches(m, c))).map(m => m.original),
+    onlyInDocs,
+    onlyInCode,
+    matched,
   };
 }
 

--- a/cli/validators/docs-diff.mjs
+++ b/cli/validators/docs-diff.mjs
@@ -171,7 +171,8 @@ function diffTests(dir, config) {
   const codeArr = [...codeTests];
 
   // PERFORMANCE OPTIMIZATION: Pre-compile regular expressions to avoid O(N*M)
-  // instantiation bottlenecks inside the nested .filter and .some loops below.
+  // instantiation bottlenecks. Pre-compute basename() to avoid O(N*M) string processing.
+  // Collapse nested filter/some loops into a single iteration block to reduce array allocations.
   const docMatchers = [...docTests].map(docEntry => {
     const entry = String(docEntry).trim();
     const hasSlash = entry.includes('/');
@@ -188,15 +189,36 @@ function diffTests(dir, config) {
     };
   });
 
-  const matches = (matcher, codeRel) => {
-    const subject = matcher.hasSlash ? codeRel : basename(codeRel);
-    return matcher.rx.test(subject);
-  };
+  const codeArrProcessed = codeArr.map(c => ({
+    original: c,
+    basename: basename(c)
+  }));
+
+  const onlyInDocs = [];
+  const codeMatched = new Set();
+
+  for (const m of docMatchers) {
+    let mMatched = false;
+    for (const c of codeArrProcessed) {
+      const subject = m.hasSlash ? c.original : c.basename;
+      if (m.rx.test(subject)) {
+        mMatched = true;
+        codeMatched.add(c.original);
+      }
+    }
+    if (!mMatched) {
+      onlyInDocs.push(m.original);
+    }
+  }
+
+  const onlyInCode = codeArrProcessed
+    .filter(c => !codeMatched.has(c.original))
+    .map(c => c.original);
 
   return {
     title: 'Test Files',
-    onlyInDocs: docMatchers.filter(m => !codeArr.some(c => matches(m, c))).map(m => m.original),
-    onlyInCode: codeArr.filter(c => !docMatchers.some(m => matches(m, c))),
+    onlyInDocs,
+    onlyInCode,
   };
 }
 


### PR DESCRIPTION
💡 What: Pre-computes `basename()` on code arrays to avoid calling it repeatedly inside nested array comparisons, and collapses multiple `.filter()` and `.some()` loops into a single O(N*M) traversal loop for matching test files against canonical spec files in `cli/commands/diff.mjs` and `cli/validators/docs-diff.mjs`.
🎯 Why: Executing expensive string functions like `basename()` dynamically inside deeply nested `.filter(m => !code.some(c => basename(c)))` loops causes severe O(N*M) algorithmic performance bottlenecks when evaluating two large arrays (e.g. hundreds of tests against dozens of documented specifications). 
📊 Impact: Reduces array allocations from intermediate `.map`, `.filter`, and `.some` calls significantly. Substantially decreases function execution counts from thousands of redundant closures and `basename()` invocations down to N+M static evaluations and N*M fast regex test executions.
🔬 Measurement: Run `node --test tests/*.test.mjs` and observe the test execution latency for `doc-diff.test.mjs` suite, particularly in repositories with extensive test suites.

---
*PR created automatically by Jules for task [2986755606426239032](https://jules.google.com/task/2986755606426239032) started by @raccioly*