### PR TITLE
⚡ Bolt: [performance improvement] Collapse nested loops and pre-compute basenames in test diffing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Performance**: Prevent redundant path basename processing inside O(N*M) test file diffing loops in `diff` and `docs-diff` commands.
+
 ## [0.25.0] - 2026-06-03
 
 Field-report follow-up from dogfooding v0.24.0 on a real stdlib-only Python CLI

--- a/cli/commands/diff.mjs
+++ b/cli/commands/diff.mjs
@@ -363,17 +363,41 @@ function diffTests(dir, config = {}) {
     };
   });
 
-  const matches = (matcher, codeRel) => {
-    const subject = matcher.hasSlash ? codeRel : basename(codeRel);
-    return matcher.rx.test(subject);
-  };
+  // Further optimization: pre-compute basenames for code entries to avoid repeated
+  // path.basename() calls, and collapse the O(N*M) lookups into a single pass.
+  const codeTargets = codeArr.map(c => ({
+    original: c,
+    base: basename(c)
+  }));
+
+  const onlyInDocs = [];
+  const matched = [];
+  const codeMatched = new Set();
+
+  for (const m of docMatchers) {
+    let hasMatch = false;
+    for (const c of codeTargets) {
+      const subject = m.hasSlash ? c.original : c.base;
+      if (m.rx.test(subject)) {
+        hasMatch = true;
+        codeMatched.add(c.original);
+      }
+    }
+    if (hasMatch) {
+      matched.push(m.original);
+    } else {
+      onlyInDocs.push(m.original);
+    }
+  }
+
+  const onlyInCode = codeArr.filter(c => !codeMatched.has(c));
 
   return {
     title: 'Test Files',
     icon: '🧪',
-    onlyInDocs: docMatchers.filter(m => !codeArr.some(c => matches(m, c))).map(m => m.original),
-    onlyInCode: codeArr.filter(c => !docMatchers.some(m => matches(m, c))),
-    matched: docMatchers.filter(m => codeArr.some(c => matches(m, c))).map(m => m.original),
+    onlyInDocs,
+    onlyInCode,
+    matched,
   };
 }
 

--- a/cli/validators/docs-diff.mjs
+++ b/cli/validators/docs-diff.mjs
@@ -188,15 +188,36 @@ function diffTests(dir, config) {
     };
   });
 
-  const matches = (matcher, codeRel) => {
-    const subject = matcher.hasSlash ? codeRel : basename(codeRel);
-    return matcher.rx.test(subject);
-  };
+  // Further optimization: pre-compute basenames for code entries to avoid repeated
+  // path.basename() calls, and collapse the O(N*M) lookups into a single pass.
+  const codeTargets = codeArr.map(c => ({
+    original: c,
+    base: basename(c)
+  }));
+
+  const onlyInDocs = [];
+  const codeMatched = new Set();
+
+  for (const m of docMatchers) {
+    let hasMatch = false;
+    for (const c of codeTargets) {
+      const subject = m.hasSlash ? c.original : c.base;
+      if (m.rx.test(subject)) {
+        hasMatch = true;
+        codeMatched.add(c.original);
+      }
+    }
+    if (!hasMatch) {
+      onlyInDocs.push(m.original);
+    }
+  }
+
+  const onlyInCode = codeArr.filter(c => !codeMatched.has(c));
 
   return {
     title: 'Test Files',
-    onlyInDocs: docMatchers.filter(m => !codeArr.some(c => matches(m, c))).map(m => m.original),
-    onlyInCode: codeArr.filter(c => !docMatchers.some(m => matches(m, c))),
+    onlyInDocs,
+    onlyInCode,
   };
 }
 


### PR DESCRIPTION
💡 **What:** Eliminated redundant string processing in test file diffing loops by pre-computing `path.basename()` into target objects upfront, then collapsing multiple `.filter()` and `.some()` array iterations into a single O(N*M) pass per document test pattern.

🎯 **Why:** The test diffing logic in `cli/commands/diff.mjs` and `cli/validators/docs-diff.mjs` previously relied on nested array iterations where string operations (like `basename`) were recalculated repeatedly inside the hot path. For larger codebases with hundreds of test files, this caused redundant CPU overhead.

📊 **Impact:** Reduces redundant string processing calls by a significant factor proportional to `(Test Files) * (Documented Patterns)`, accelerating the `diff` and `docs-diff` checks for large projects without altering the logical behavior or correctness of the alignment output.

🔬 **Measurement:** Execute `node --test tests/*.test.mjs` to confirm regression-free behavior. The `npm-pack-smoke` or similar existing end-to-end trace tests effectively validate this core pathway.

---
*PR created automatically by Jules for task [16289730614959391712](https://jules.google.com/task/16289730614959391712) started by @raccioly*