### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix command injection vulnerability pattern in score command

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Found multiple instances where user-controlled inputs (`projectDir`, `filePath`) were interpolated directly into shell commands via `execSync` (e.g., `execSync(\`node "\${cliPath}" init --dir "\${projectDir}"\`)`).
 **Learning:** This is a classic command injection vulnerability. If `projectDir` contains shell metacharacters like `;`, `&&`, or `||`, it allows arbitrary command execution.
 **Prevention:** Always use `execFileSync` (or `execFile` for async) instead of `execSync` when executing commands with dynamic inputs. Pass arguments as an array to ensure they are passed directly to the executable without shell interpolation.
+
+## 2025-05-20 - [Shell Injection via execSync in git log | wc -l]
+**Vulnerability:** Found `execSync('git log --oneline --since="30 days ago" 2>/dev/null | wc -l', {cwd: projectDir})`.
+**Learning:** Even without explicit user input, using `execSync` is inherently risky as it invokes a shell and can be subjected to environment or command manipulation. Additionally, `execSync` uses a limited buffer size by default, making output like `git log` susceptible to ENOBUFS crashes.
+**Prevention:** Always use `execFileSync` to avoid shell invocation. For emulating piping, perform the calculation natively in javascript (e.g. splitting standard output by newlines). When reading substantial output, configure the `maxBuffer` property to comfortably accommodate the expected size.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Command Injection Prevention** — replaced shell execution (`execSync`) with native `execFileSync` in `cli/commands/score.mjs` for calculating recent commits to prevent potential shell metacharacter exploitation.
+
 ## [0.25.0] - 2026-06-03
 
 Field-report follow-up from dogfooding v0.24.0 on a real stdlib-only Python CLI

--- a/cli/commands/score.mjs
+++ b/cli/commands/score.mjs
@@ -5,7 +5,7 @@
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { resolve, join, extname } from 'node:path';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { c, docHasSection } from '../shared.mjs';
 import { validateSecurity } from '../validators/security.mjs';
 import { runGuardInternal } from './guard.mjs';
@@ -942,11 +942,13 @@ function estimateDocTax(projectDir, config, scores) {
   // Estimate code churn (commits in last 30 days)
   let recentCommits = 0;
   try {
-    const output = execSync('git log --oneline --since="30 days ago" 2>/dev/null | wc -l', {
+    const output = execFileSync('git', ['log', '--oneline', '--since="30 days ago"'], {
       cwd: projectDir,
       encoding: 'utf-8',
-    }).trim();
-    recentCommits = parseInt(output, 10) || 0;
+      stdio: ['pipe', 'pipe', 'ignore'],
+      maxBuffer: 1024 * 1024 * 5
+    });
+    recentCommits = output.trim().split('\n').filter(Boolean).length;
   } catch {
     recentCommits = 10; // Default assumption
   }


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The `runScore` function inside `cli/commands/score.mjs` was using `execSync` with shell syntax (`| wc -l` and `2>/dev/null`) to parse recent git commits. While not immediately exploitable by end-user input, invoking shell executors is a persistent command injection hazard, making the app vulnerable to future edits or environment-based payloads. Additionally, `execSync` buffer exhaustion could lead to `ENOBUFS` failure.
🎯 **Impact:** Prevents potential arbitrary command execution from malicious `projectDir` structures or future string interpolations and hardens application stability when interacting with large git repositories.
🔧 **Fix:** Refactored the calculation to use `execFileSync`, entirely dropping shell invocation. Shell-specific capabilities like pipe counting and error suppression were emulated natively via JavaScript splitting/filtering and process `stdio` arrays, respectively. Set `maxBuffer` limit to properly accommodate large git logs. Also updated `CHANGELOG.md` and added a journal entry.
✅ **Verification:** Verified fix through local test suite runs, achieving full pass rate. Code review confirms functional parity with previous behavior without introducing regressions.

---
*PR created automatically by Jules for task [14115018863358737973](https://jules.google.com/task/14115018863358737973) started by @raccioly*