### PR TITLE
⚡ Bolt: [performance improvement] Precompute Map for OpenAPI Schema Relationship Lookups

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,6 @@
 ## 2024-05-24 - Pre-compile RegExp in nested loops
 **Learning:** Instantiating `new RegExp()` inside nested array methods like `.filter` and `.some` creates a severe O(N*M) performance bottleneck, especially when matching two large lists (e.g., documented tests vs. actual test files).
 **Action:** Always pre-compile regular expressions and derived strings into an array of "matcher" objects outside of the loop before iterating, which shifts the instantiation cost from O(N*M) to O(N).
+## 2024-05-24 - Precompute Maps to avoid O(N^2) Array searches
+**Learning:** Using `Array.find()` inside nested loops (e.g., when resolving schema references across F fields in N schemas) creates an O(N^2) performance bottleneck.
+**Action:** Always precompute an O(1) `Map` lookup (e.g., `schema.name.toLowerCase()` -> `schema`) before the loops to reduce the time complexity from O(N^2) to O(N).

--- a/cli/scanners/schemas.mjs
+++ b/cli/scanners/schemas.mjs
@@ -713,11 +713,19 @@ function scanRailsModels(dir) {
 
 function extractOpenAPIRelationships(schemas) {
   const relationships = [];
+
+  // PERFORMANCE OPTIMIZATION: Precompute an O(1) Map lookup of lowercased schema names
+  // instead of using a nested Array.find() search to avoid an O(N^2) algorithmic bottleneck.
+  const schemaMap = new Map();
+  for (const schema of schemas) {
+    schemaMap.set(schema.name.toLowerCase(), schema);
+  }
+
   for (const schema of schemas) {
     for (const field of schema.fields) {
       if (field.type !== 'string' && field.type !== 'number' && field.type !== 'boolean' && field.type !== 'integer') {
         // Likely a reference to another schema
-        const target = schemas.find(s => s.name.toLowerCase() === field.type.toLowerCase());
+        const target = schemaMap.get(field.type.toLowerCase());
         if (target) {
           relationships.push({
             from: schema.name,


### PR DESCRIPTION
💡 **What:** Replaced the nested `Array.find()` call within `extractOpenAPIRelationships` with an $O(1)$ `Map` lookup.

🎯 **Why:** The previous implementation searched the entire `schemas` array for every non-primitive field across all schemas. This created an $O(N^2)$ algorithmic bottleneck, scaling poorly for projects with large numbers of complex OpenAPI schema entities.

📊 **Impact:** Reduces the time complexity of the relationship extraction step from $O(N^2)$ to $O(N)$ (where $N$ is the number of fields to process across all schemas). This significantly speeds up the processing time for extracting relationships from OpenAPI definitions.

🔬 **Measurement:** Code changes can be verified visually; the performance gain is mathematically guaranteed by eliminating an unnecessary loop. Furthermore, the test suite (`node --test tests/*.test.mjs`) passes cleanly with no regressions to schema extraction correctness.

---
*PR created automatically by Jules for task [12061550447868220352](https://jules.google.com/task/12061550447868220352) started by @raccioly*