### PR TITLE
⚡ Bolt: [performance improvement] Optimize docguard trace command loops and array operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-05-24 - Pre-compile RegExp in nested loops
 **Learning:** Instantiating `new RegExp()` inside nested array methods like `.filter` and `.some` creates a severe O(N*M) performance bottleneck, especially when matching two large lists (e.g., documented tests vs. actual test files).
 **Action:** Always pre-compile regular expressions and derived strings into an array of "matcher" objects outside of the loop before iterating, which shifts the instantiation cost from O(N*M) to O(N).
+
+## 2024-05-25 - Variable shadowing in map/reduce
+**Learning:** When refactoring multiple redundant `.filter().length` array queries into a single-pass `.reduce()` loop that returns an object, ensure any conditionals immediately following the loop that depend on the old loop variables are updated to reference the properties of the returned object (e.g., updating `missing > 0` to `stats.missing > 0`). Leaving dangling variable references will cause a ReferenceError.
+**Action:** Always carefully trace where variables computed from array operations are consumed later in the function block, and verify changes with unit tests or type checkers before merging.

--- a/cli/commands/trace.mjs
+++ b/cli/commands/trace.mjs
@@ -161,6 +161,11 @@ export function runTrace(projectDir, config, flags) {
   const projectFiles = [];
   scanDir(projectDir, projectDir, projectFiles);
 
+  // PERFORMANCE OPTIMIZATION: Precompute filtered file lists to avoid O(N*M)
+  // filtering bottlenecks inside the TRACE_MAP nested loops.
+  const traceableFiles = projectFiles.filter(isTraceableSource);
+  const testFiles = projectFiles.filter(f => TEST_PATTERNS.some(p => p.test(f)));
+
   // ── 4. Build traceability matrix (only required docs) ──
   const matrix = [];
   const orphanedDocs = [];
@@ -189,7 +194,7 @@ export function runTrace(projectDir, config, flags) {
     // Find matching source files for each pattern
     const traces = [];
     for (const pattern of traceInfo.sourcePatterns) {
-      const matches = projectFiles.filter(f => isTraceableSource(f) && pattern.glob.test(f));
+      const matches = traceableFiles.filter(f => pattern.glob.test(f));
       traces.push({
         label: pattern.label,
         matchCount: matches.length,
@@ -199,7 +204,7 @@ export function runTrace(projectDir, config, flags) {
     }
 
     // Find test coverage (files that test code related to this doc)
-    const relatedTests = findRelatedTests(projectFiles, traceInfo.sourcePatterns);
+    const relatedTests = findRelatedTests(traceableFiles, testFiles, traceInfo.sourcePatterns);
 
     // Calculate coverage signal
     const totalSources = traces.reduce((sum, t) => sum + t.matchCount, 0);
@@ -245,10 +250,11 @@ function outputJSON(projectName, matrix, orphanedDocs) {
     orphanedDocs,
     summary: {
       total: matrix.length,
-      traced: matrix.filter(m => m.coverageSignal === 'TRACED').length,
-      partial: matrix.filter(m => m.coverageSignal === 'PARTIAL').length,
-      unlinked: matrix.filter(m => m.coverageSignal === 'UNLINKED').length,
-      missing: matrix.filter(m => m.coverageSignal === 'MISSING').length,
+      ...matrix.reduce((acc, m) => {
+        const key = m.coverageSignal.toLowerCase();
+        acc[key] = (acc[key] || 0) + 1;
+        return acc;
+      }, { traced: 0, partial: 0, unlinked: 0, missing: 0 }),
       orphaned: orphanedDocs.length,
     },
     timestamp: new Date().toISOString(),
@@ -314,16 +320,17 @@ function outputText(projectName, matrix, canonicalDocs, orphanedDocs) {
   }
 
   // Summary
-  const traced = matrix.filter(m => m.coverageSignal === 'TRACED').length;
-  const partial = matrix.filter(m => m.coverageSignal === 'PARTIAL').length;
-  const unlinked = matrix.filter(m => m.coverageSignal === 'UNLINKED').length;
-  const missing = matrix.filter(m => m.coverageSignal === 'MISSING').length;
+  const stats = matrix.reduce((acc, m) => {
+    const key = m.coverageSignal.toLowerCase();
+    acc[key] = (acc[key] || 0) + 1;
+    return acc;
+  }, { traced: 0, partial: 0, unlinked: 0, missing: 0 });
 
   console.log(`  ${c.bold}─────────────────────────────────────${c.reset}`);
-  console.log(`  ${c.green}Traced: ${traced}${c.reset}  ${c.yellow}Partial: ${partial}${c.reset}  ${c.yellow}Unlinked: ${unlinked}${c.reset}  ${c.red}Missing: ${missing}${c.reset}`);
+  console.log(`  ${c.green}Traced: ${stats.traced}${c.reset}  ${c.yellow}Partial: ${stats.partial}${c.reset}  ${c.yellow}Unlinked: ${stats.unlinked}${c.reset}  ${c.red}Missing: ${stats.missing}${c.reset}`);
   console.log(`  ${c.dim}Total: ${matrix.length} canonical documents evaluated${c.reset}`);
 
-  if (missing > 0 || unlinked > 0) {
+  if (stats.missing > 0 || stats.unlinked > 0) {
     console.log(`\n  ${c.dim}Run ${c.cyan}docguard generate${c.dim} to create missing docs.${c.reset}`);
     console.log(`  ${c.dim}Run ${c.cyan}docguard diagnose${c.dim} to fix coverage gaps.${c.reset}`);
   }
@@ -366,15 +373,12 @@ function scanDir(rootDir, dir, files) {
   }
 }
 
-function findRelatedTests(projectFiles, sourcePatterns) {
-  // Find test files that might cover the source patterns
-  const testFiles = projectFiles.filter(f => TEST_PATTERNS.some(p => p.test(f)));
-
+function findRelatedTests(traceableFiles, testFiles, sourcePatterns) {
   // Match tests to source patterns by directory/name proximity
   const relatedTests = new Set();
 
   for (const pattern of sourcePatterns) {
-    const sourceFiles = projectFiles.filter(f => isTraceableSource(f) && pattern.glob.test(f));
+    const sourceFiles = traceableFiles.filter(f => pattern.glob.test(f));
     for (const src of sourceFiles) {
       const srcBase = basename(src).replace(/\.[^.]+$/, '');
       const srcDir = src.split('/')[0];


### PR DESCRIPTION
💡 What: Refactored `cli/commands/trace.mjs` to precompute `traceableFiles` and `testFiles` arrays instead of repeatedly filtering the entire `projectFiles` array inside nested loops for each `TRACE_MAP` document and pattern. Additionally, replaced multiple sequential `.filter().length` array queries with a single-pass `.reduce()` operation when generating summary statistics.

🎯 Why: To eliminate an O(N*M) algorithmic performance bottleneck caused by repeatedly running identical regex tests and filtering functions on the full file list across multiple nested loops.

📊 Impact: Reduces redundant file list filtering, significantly improving the execution time of the `docguard trace` command, especially on large repositories with many files and documents.

🔬 Measurement: Run the test suite (`node --test tests/traceability.test.mjs`) to verify correctness, and test `docguard trace` on a large codebase to observe the speedup.

---
*PR created automatically by Jules for task [1230092058658835161](https://jules.google.com/task/1230092058658835161) started by @raccioly*