### PR TITLE
fix(ci): keep oversized fields out of the spec-kit submission URL

### DIFF
--- a/.github/scripts/speckit-submission.py
+++ b/.github/scripts/speckit-submission.py
@@ -183,14 +183,34 @@ def render_body(fields, checkbox_items) -> str:
     return "\n\n".join(blocks) + "\n"
 
 
+# Large free-text fields overflow GitHub's URL length limit (~8 KB) — the form
+# then returns "Whoa there! Your request URL is too long." and prefills NOTHING.
+# Keep these OUT of the prefilled URL; they live in the --body paste-fallback,
+# which the issue surfaces in a copy/paste <details> block. The URL prefills the
+# short, high-value identity fields; the human pastes the rest.
+URL_OMIT = {"features", "testing-details", "example-usage",
+            "catalog-entry", "additional-context"}
+
+# Conservative cap (well under GitHub's limit) so the one-click link always loads.
+URL_MAX = 6000
+
+
 def render_url(fields, version) -> str:
     params = {"template": TEMPLATE,
               "title": f"[Extension]: Update DocGuard — CDD Enforcement (v{version})"}
     for fid, _label, value in fields:
-        if value is None:
-            continue  # checkbox groups can't be prefilled via URL
+        if value is None or fid in URL_OMIT:
+            continue  # checkbox groups + oversized fields are paste-only
         params[fid] = value
-    return FORM_URL + "?" + urlencode(params, quote_via=quote)
+    url = FORM_URL + "?" + urlencode(params, quote_via=quote)
+    # Safety net: if still too long, shed the longest optional fields until it
+    # fits. (Identity fields — id/name/version/urls — are always kept.)
+    for fid in ("required-tools", "tags", "description", "documentation", "changelog"):
+        if len(url) <= URL_MAX:
+            break
+        params.pop(fid, None)
+        url = FORM_URL + "?" + urlencode(params, quote_via=quote)
+    return url
 
 
 def main():


### PR DESCRIPTION
The prefilled spec-kit Extension Submission URL overflowed GitHub's ~8 KB limit (`Whoa there! Your request URL is too long.`) because `render_url` put every field — including the multi-KB `catalog-entry` JSON and full release notes — into the query string. v0.26.0's reminder ([#245](https://github.com/raccioly/docguard/issues/245)) hit it and prefilled nothing.

**Fix:** `render_url` omits the five oversized free-text fields (`features`, `testing-details`, `example-usage`, `catalog-entry`, `additional-context`) from the URL — they stay in the `--body` paste-fallback the reminder issue already surfaces — plus a `URL_MAX` safety net. The v0.26.0 URL goes ~7 KB → ~1.4 KB; identity fields always kept.

Issue #245 has already been refreshed with the working URL. CI-tooling only — does not touch `package.json`, so no release is triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)