### PR TITLE
⚡ Bolt: [performance improvement] Precompute Map in extractOpenAPIRelationships

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-05-24 - Pre-compile RegExp in nested loops
 **Learning:** Instantiating `new RegExp()` inside nested array methods like `.filter` and `.some` creates a severe O(N*M) performance bottleneck, especially when matching two large lists (e.g., documented tests vs. actual test files).
 **Action:** Always pre-compile regular expressions and derived strings into an array of "matcher" objects outside of the loop before iterating, which shifts the instantiation cost from O(N*M) to O(N).
+
+## 2024-05-25 - [O(1) Map Lookup for Relationships]
+**Learning:** In `cli/scanners/schemas.mjs`, `extractOpenAPIRelationships` had an O(N^2) algorithmic bottleneck due to a nested `Array.find` search. For large schemas, this scales poorly.
+**Action:** Replaced the nested `Array.find` with a precomputed O(1) `Map` lookup of lowercased schema names. Always precompute lookups outside of nested loops when matching lists.

--- a/cli/scanners/schemas.mjs
+++ b/cli/scanners/schemas.mjs
@@ -713,11 +713,21 @@ function scanRailsModels(dir) {
 
 function extractOpenAPIRelationships(schemas) {
   const relationships = [];
+
+  // PERFORMANCE OPTIMIZATION: Precompute an O(1) Map lookup of lowercased schema names
+  // to avoid an O(N^2) algorithmic bottleneck from using a nested Array.find search.
+  const schemaMap = new Map();
+  for (const s of schemas) {
+    if (s.name) {
+      schemaMap.set(s.name.toLowerCase(), s);
+    }
+  }
+
   for (const schema of schemas) {
     for (const field of schema.fields) {
       if (field.type !== 'string' && field.type !== 'number' && field.type !== 'boolean' && field.type !== 'integer') {
         // Likely a reference to another schema
-        const target = schemas.find(s => s.name.toLowerCase() === field.type.toLowerCase());
+        const target = schemaMap.get(field.type.toLowerCase());
         if (target) {
           relationships.push({
             from: schema.name,


### PR DESCRIPTION
💡 **What:**
Replaced the nested `Array.find` inside `extractOpenAPIRelationships` (located in `cli/scanners/schemas.mjs`) with a precomputed O(1) `Map` lookup.

🎯 **Why:**
Using `.find()` within a nested loop created an $O(N^2)$ algorithmic bottleneck, causing unnecessary overhead and poor scaling when scanning projects with a large number of OpenAPI schemas and complex relationships. 

📊 **Impact:**
Reduces the time complexity of the relationship extraction phase from $O(N^2)$ to $O(N)$, significantly speeding up relationship resolution for large projects with many OpenAPI schemas and fields. It also adds a safety check for schemas without a name.

🔬 **Measurement:**
Run the test suite `node --test tests/*.test.mjs` to ensure the relationships are still accurately extracted without any regressions. The execution time of relationship extraction for large schema inputs will be demonstrably faster.

---
*PR created automatically by Jules for task [6793119485057088196](https://jules.google.com/task/6793119485057088196) started by @raccioly*