### PR TITLE
feat(mcp): glama.json + read-only tool annotations (Glama score)

### DIFF
--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -1,7 +1,7 @@
 # anatomy.md
 
-> Auto-maintained by OpenWolf. Last scanned: 2026-07-05T16:10:27.214Z
-> Files: 662 tracked | Anatomy hits: 0 | Misses: 0
+> Auto-maintained by OpenWolf. Last scanned: 2026-07-06T00:34:30.826Z
+> Files: 663 tracked | Anatomy hits: 0 | Misses: 0
 
 ## ../../../../../../../tmp/
 
@@ -32,6 +32,7 @@
 - `docguard-cli-0.23.0.tgz` (~81238 tok)
 - `Dockerfile` — Docker container definition (~204 tok)
 - `DRIFT-LOG.md` — Drift Log (~802 tok)
+- `glama.json` (~29 tok)
 - `LICENSE` — Project license (~286 tok)
 - `package-lock.json` — npm lock file (~617 tok)
 - `package.json` — Node.js package manifest (~459 tok)
@@ -39,7 +40,7 @@
 - `pr_description.md` (~260 tok)
 - `pyproject.toml` — The enforcement tool for Canonical-Driven Development (CDD). Audit, generate, and guard your project (~358 tok)
 - `README.es.md` — 🛡️ DocGuard (~1098 tok)
-- `README.md` — Project documentation (~8376 tok)
+- `README.md` — Project documentation (~8436 tok)
 - `README.pt-BR.md` — 🛡️ DocGuard (~1075 tok)
 - `ROADMAP.md` — DocGuard Roadmap (~2432 tok)
 - `SECURITY.md` — Security Policy (~357 tok)
@@ -973,7 +974,7 @@
 - `guard.mjs` — Guard Command — Validate project against its canonical documentation (~11608 tok)
 - `init.mjs` — Init Command — Initialize CDD documentation from templates (~7278 tok)
 - `llms.mjs` — llms Command — Generate llms.txt from canonical documentation (~2137 tok)
-- `mcp.mjs` — MCP Command — DocGuard as a Model Context Protocol server (stdio). (~2902 tok)
+- `mcp.mjs` — MCP Command — DocGuard as a Model Context Protocol server (stdio). (~3098 tok)
 - `memory.mjs` — Memory Command — v0.17-P2. (~2957 tok)
 - `score.mjs` — Score Command — Calculate CDD maturity score (0-100) (~12136 tok)
 - `sync-tests.mjs` — `docguard sync --tests` — reconcile the TEST-SPEC Source-to-Test Map from disk. (~3191 tok)
@@ -1025,7 +1026,7 @@
 
 ## docs-canonical/
 
-- `ARCHITECTURE.md` — Architecture (~2967 tok)
+- `ARCHITECTURE.md` — Architecture (~3029 tok)
 - `DATA-MODEL.md` — Data Model (~1668 tok)
 - `REQUIREMENTS.md` — Requirements (~673 tok)
 - `SURFACE-AUDIT.md` — DocGuard Surface Audit (~5703 tok)

--- a/.wolf/hooks/_session.json
+++ b/.wolf/hooks/_session.json
@@ -1,23 +1,67 @@
 {
-  "session_id": "session-2026-07-05-1205",
-  "started": "2026-07-05T16:05:31.122Z",
+  "session_id": "session-2026-07-06-2028",
+  "started": "2026-07-06T00:28:14.541Z",
   "files_read": {
-    "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/CHANGELOG.md": {
+    "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/cli/commands/mcp.mjs": {
       "count": 1,
-      "tokens": 45074,
-      "first_read": "2026-07-05T16:10:17.439Z"
+      "tokens": 2902,
+      "first_read": "2026-07-06T00:31:54.545Z"
     }
   },
   "files_written": [
     {
-      "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/CHANGELOG.md",
+      "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/glama.json",
+      "action": "create",
+      "tokens": 29,
+      "at": "2026-07-06T00:32:39.801Z"
+    },
+    {
+      "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/cli/commands/mcp.mjs",
       "action": "edit",
-      "tokens": 35,
-      "at": "2026-07-05T16:10:27.228Z"
+      "tokens": 172,
+      "at": "2026-07-06T00:32:47.315Z"
+    },
+    {
+      "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/cli/commands/mcp.mjs",
+      "action": "edit",
+      "tokens": 141,
+      "at": "2026-07-06T00:33:10.867Z"
+    },
+    {
+      "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/cli/commands/mcp.mjs",
+      "action": "edit",
+      "tokens": 89,
+      "at": "2026-07-06T00:33:16.951Z"
+    },
+    {
+      "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/cli/commands/mcp.mjs",
+      "action": "edit",
+      "tokens": 166,
+      "at": "2026-07-06T00:33:24.421Z"
+    },
+    {
+      "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/cli/commands/mcp.mjs",
+      "action": "edit",
+      "tokens": 129,
+      "at": "2026-07-06T00:33:36.158Z"
+    },
+    {
+      "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/cli/commands/mcp.mjs",
+      "action": "edit",
+      "tokens": 114,
+      "at": "2026-07-06T00:33:45.859Z"
+    },
+    {
+      "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/docs-canonical/ARCHITECTURE.md",
+      "action": "edit",
+      "tokens": 118,
+      "at": "2026-07-06T00:34:30.839Z"
     }
   ],
   "edit_counts": {
-    "CHANGELOG.md": 1
+    "glama.json": 1,
+    "cli/commands/mcp.mjs": 6,
+    "docs-canonical/ARCHITECTURE.md": 1
   },
   "anatomy_hits": 1,
   "anatomy_misses": 0,

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -824,3 +824,39 @@
 | Time | Action | File(s) | Outcome | ~Tokens |
 |------|--------|---------|---------|--------|
 | 12:10 | Edited CHANGELOG.md | 3→5 lines | ~33 |
+| 12:15 | Session end: 1 writes across 1 files (CHANGELOG.md) | 1 reads | ~45109 tok |
+
+## Session: 2026-07-05 12:38
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-07-05 13:27
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-07-05 14:23
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 14:34 | Edited README.md | 1→3 lines | ~97 |
+| 14:35 | Session end: 1 writes across 1 files (README.md) | 1 reads | ~8480 tok |
+
+## Session: 2026-07-05 18:45
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+
+## Session: 2026-07-06 20:28
+
+| Time | Action | File(s) | Outcome | ~Tokens |
+|------|--------|---------|---------|--------|
+| 20:32 | Created glama.json | — | ~29 |
+| 20:32 | Edited cli/commands/mcp.mjs | expanded (+10 lines) | ~161 |
+| 20:33 | Edited cli/commands/mcp.mjs | 7→9 lines | ~131 |
+| 20:33 | Edited cli/commands/mcp.mjs | 7→9 lines | ~83 |
+| 20:33 | Edited cli/commands/mcp.mjs | modified code() | ~155 |
+| 20:33 | Edited cli/commands/mcp.mjs | 7→9 lines | ~120 |
+| 20:33 | Edited cli/commands/mcp.mjs | 8→10 lines | ~106 |
+| 20:34 | Edited docs-canonical/ARCHITECTURE.md | 1→3 lines | ~111 |

--- a/.wolf/token-ledger.json
+++ b/.wolf/token-ledger.json
@@ -2,14 +2,14 @@
   "version": 1,
   "created_at": "2026-05-26T15:31:59.491Z",
   "lifetime": {
-    "total_tokens_estimated": 5840829,
-    "total_reads": 1499,
-    "total_writes": 2298,
-    "total_sessions": 33,
-    "anatomy_hits": 915,
+    "total_tokens_estimated": 5894418,
+    "total_reads": 1501,
+    "total_writes": 2300,
+    "total_sessions": 38,
+    "anatomy_hits": 917,
     "anatomy_misses": 580,
     "repeated_reads_blocked": 918,
-    "estimated_savings_vs_bare_cli": 5185233
+    "estimated_savings_vs_bare_cli": 5185633
   },
   "sessions": [
     {
@@ -21761,6 +21761,62 @@
         "writes_count": 77,
         "repeated_reads_blocked": 18,
         "anatomy_lookups": 28
+      }
+    },
+    {
+      "id": "session-2026-07-05-1205",
+      "started": "2026-07-05T16:05:31.122Z",
+      "ended": "2026-07-05T16:15:20.418Z",
+      "reads": [
+        {
+          "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/CHANGELOG.md",
+          "tokens_estimated": 45074,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/CHANGELOG.md",
+          "tokens_estimated": 35,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 45074,
+        "output_tokens_estimated": 35,
+        "reads_count": 1,
+        "writes_count": 1,
+        "repeated_reads_blocked": 0,
+        "anatomy_lookups": 1
+      }
+    },
+    {
+      "id": "session-2026-07-05-1423",
+      "started": "2026-07-05T18:23:53.856Z",
+      "ended": "2026-07-05T18:35:41.948Z",
+      "reads": [
+        {
+          "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/README.md",
+          "tokens_estimated": 8376,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/README.md",
+          "tokens_estimated": 104,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 8376,
+        "output_tokens_estimated": 104,
+        "reads_count": 1,
+        "writes_count": 1,
+        "repeated_reads_blocked": 0,
+        "anatomy_lookups": 1
       }
     }
   ],

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 [![Node.js](https://img.shields.io/badge/Node.js-18%2B-green)](https://nodejs.org)
 [![Runtime deps](https://img.shields.io/badge/runtime_deps-1_(pinned)-green)](package.json)
 [![Spec Kit Extension](https://img.shields.io/badge/Spec_Kit-Extension-blueviolet)](https://github.com/github/spec-kit)
+[![Glama](https://glama.ai/mcp/servers/raccioly/docguard/badges/score.svg)](https://glama.ai/mcp/servers/raccioly/docguard)
+[![MCP Registry](https://img.shields.io/badge/MCP_Registry-listed-0a7ea4)](https://registry.modelcontextprotocol.io/)
 
 ---
 

--- a/cli/commands/mcp.mjs
+++ b/cli/commands/mcp.mjs
@@ -53,25 +53,40 @@ const PROJECT_DIR_PROP = {
   },
 };
 
+// Every DocGuard MCP tool is READ-ONLY: it inspects local project files and
+// never writes, mutates, or reaches the network. These MCP tool hints let
+// clients (and directory scanners like Glama) surface that safety to users.
+const READONLY_ANNOTATIONS = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+};
+
 const TOOLS = [
   {
     name: 'docguard_guard',
+    title: 'Guard docs against code',
     description: 'Run every enabled DocGuard validator against the project\'s canonical docs. Returns the full guard JSON contract: status (PASS/WARN/FAIL), structured findings with stable codes and suggestions, nextStep, doc coverage map, semantic-claim count, and per-validator results.',
     inputSchema: {
       type: 'object',
       properties: { ...PROJECT_DIR_PROP },
     },
+    annotations: READONLY_ANNOTATIONS,
   },
   {
     name: 'docguard_score',
+    title: 'CDD maturity score',
     description: 'Compute the project\'s CDD maturity score (0-100) with letter grade and per-category breakdown.',
     inputSchema: {
       type: 'object',
       properties: { ...PROJECT_DIR_PROP },
     },
+    annotations: READONLY_ANNOTATIONS,
   },
   {
     name: 'docguard_explain',
+    title: 'Explain a finding code',
     description: 'Explain a stable DocGuard finding code (e.g. STR001, ENV003): what it means, which validator emits it, and the inline suppression to use if it\'s a confirmed false positive.',
     inputSchema: {
       type: 'object',
@@ -83,22 +98,27 @@ const TOOLS = [
       },
       required: ['code'],
     },
+    annotations: READONLY_ANNOTATIONS,
   },
   {
     name: 'docguard_verify_claims',
+    title: 'Extract claims to verify',
     description: 'Extract the semantic claims in the project\'s canonical docs — documented numbers, limits, and enums — as a verification task list. Deterministic discovery, LLM judgment — the caller verifies each claim against the code.',
     inputSchema: {
       type: 'object',
       properties: { ...PROJECT_DIR_PROP },
     },
+    annotations: READONLY_ANNOTATIONS,
   },
   {
     name: 'docguard_diagnose',
+    title: 'Diagnose what to fix',
     description: 'Run guard and return only what needs fixing: failing/warning validators with their messages, structured findings, and suggested next actions — shaped for an agent to act on.',
     inputSchema: {
       type: 'object',
       properties: { ...PROJECT_DIR_PROP },
     },
+    annotations: READONLY_ANNOTATIONS,
   },
 ];
 

--- a/docs-canonical/ARCHITECTURE.md
+++ b/docs-canonical/ARCHITECTURE.md
@@ -58,6 +58,8 @@ DocGuard recognizes and validates these project config files:
 | `.storybook/` | Component documentation tool (detected for docs-coverage) |
 | `.jules-setup.sh` | This repo's own Google Jules environment bootstrap script (internal tooling, not shipped) |
 | `.pre-commit-hooks.yaml` | This repo as a pre-commit hook source — consumers reference `repo: raccioly/docguard` to run `docguard-guard` (changed-only) per commit |
+| `glama.json` | Glama MCP directory metadata — declares repo maintainers so the Glama listing can be claimed/managed |
+| `server.json` | Official MCP Registry manifest (`io.github.raccioly/docguard`) — server name, npm package, stdio transport |
 
 ## Layer Boundaries
 

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "raccioly"
+  ]
+}


### PR DESCRIPTION
Improves DocGuard's Glama quality score:
- Adds `glama.json` (maintainers) → fixes 'No glama.json'
- MCP tools gain `title` + read-only safety annotations → serves Glama's tool-definition-quality + safety scans
- Documents the new config files in ARCHITECTURE

Docs/metadata + additive tool fields. No version bump. 7/7 mcp tests, guard PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)