### PR TITLE
docs(jules): stop the duplicate-PR flood (RESOLVED markers + no-duplicate rule)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,10 +1,24 @@
-## 2024-05-18 - [Optimization]
-**Learning:** Found string.includes early return could speed up checkUntrackedTodos in cli/validators/todo-tracking.mjs.
-**Action:** Implement fast early return with includes check before doing expensive splitting or matching.
+# Bolt — performance learnings
 
-## 2024-05-18 - [O(N*M) String Overhead]
-**Learning:** To prevent N^2 performance bottlenecks in nested loops (such as comparing a list of items against multiple documents), precomputing expensive operations like `.toLowerCase()` during the initial file load or mapping phase avoids redundant $O(N \times M)$ overhead.
-**Action:** Precompute expensive string operations and property lookups (like `.toLowerCase()` and `.substring()`) outside of inner loops and during file load mapping phases to improve scaling.
-## 2024-05-24 - Pre-compile RegExp in nested loops
-**Learning:** Instantiating `new RegExp()` inside nested array methods like `.filter` and `.some` creates a severe O(N*M) performance bottleneck, especially when matching two large lists (e.g., documented tests vs. actual test files).
-**Action:** Always pre-compile regular expressions and derived strings into an array of "matcher" objects outside of the loop before iterating, which shifts the instantiation cost from O(N*M) to O(N).
+> ⛔ **STOP / DO-NOT-DUPLICATE.** Before opening ANY PR, search existing **open
+> AND closed** PRs. Dozens of duplicate "optimize diffTests / Set cross-compare
+> / precompute toLowerCase / pre-compile RegExp" PRs were closed as noise.
+> **Do NOT open another micro-optimization PR** unless you include a **benchmark
+> showing >20% wall-clock improvement on a realistic workload** (a real repo,
+> not a synthetic loop). A theoretical Big-O note is NOT sufficient justification.
+
+## ✅ APPLIED / EVALUATED — the recurring diff & scan optimizations (do NOT re-open)
+
+The learnings below have already been applied where they helped, and the
+affected code (`cli/commands/diff.mjs`, `cli/validators/*`, the scanners) was
+substantially **refactored in v0.29–v0.30** — PRs written against the old shape
+no longer apply and just create merge noise.
+
+- **Early-return in `checkUntrackedTodos`** — already in place.
+- **Precompute `.toLowerCase()` / `.substring()` outside loops** — applied where
+  it mattered; the remaining cases are not hot paths.
+- **Pre-compile `RegExp` outside nested loops** — applied in the scanners.
+
+These are recorded as historical context, **not** as standing mandates to
+re-scan for on every run. The DocGuard test suite (898 tests) and CI already
+guard against regressions here.

--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,11 +1,11 @@
-## 2024-04-16 - Web UI Components Constraint
-**Learning:** The docguard repository consists entirely of a Node.js CLI tool and a VS Code extension; it lacks web UI components (e.g., HTML, CSS, React, Vue), meaning traditional web-focused micro-UX enhancements do not apply.
-**Action:** Do not attempt traditional web-based UX enhancements here. Focus on CLI paradigms or skip UX enhancement requests if web-centric.
+# Palette — UX learnings
 
-## 2024-04-16 - Context-Aware Status Bar Tooltips
-**Learning:** VS Code extension status bar items can display multiple forms of feedback, but static tooltips fail to explain state changes. Providing context-aware tooltip text (e.g., explaining why a threshold warning icon appears) greatly improves the usability for developers monitoring CLI outputs inline.
-**Action:** Always map status bar dynamic properties (icon, text, backgroundColor) to corresponding informative tooltips that explain what the visual change means.
+> ⛔ **STOP.** This repository has **no user-facing UI**: it is a Node.js CLI
+> plus config/docs. There is **no web frontend** (no HTML/CSS/React/Vue) and
+> **no VS Code extension** (it was removed). Palette therefore has nothing to
+> act on here. **Do NOT open UX PRs** — the past "No web UI components" /
+> "No changes required" no-op PRs were closed as noise. Skip this repo.
 
-## 2024-05-18 - Yielding Event Loop for Loading States
-**Learning:** When updating UI elements like VS Code extension `statusBarItem` to show a loading state (e.g., adding a spinner and changing tooltip) immediately prior to a synchronous, blocking operation (like `execSync`), the changes won't render unless you explicitly yield the event loop.
-**Action:** Use `await new Promise(r => setTimeout(r, 0))` right after the UI update to allow the editor time to render the visual changes before the main thread blocks.
+Historical note: earlier learnings referenced a VS Code extension (status-bar
+tooltips, loading spinners). That extension no longer exists in this repo, so
+those notes are obsolete and must not be acted on.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,24 @@
-## 2025-05-18 - [Command Injection via execSync]
-**Vulnerability:** Found multiple instances where user-controlled inputs (`projectDir`, `filePath`) were interpolated directly into shell commands via `execSync` (e.g., `execSync(\`node "\${cliPath}" init --dir "\${projectDir}"\`)`).
-**Learning:** This is a classic command injection vulnerability. If `projectDir` contains shell metacharacters like `;`, `&&`, or `||`, it allows arbitrary command execution.
-**Prevention:** Always use `execFileSync` (or `execFile` for async) instead of `execSync` when executing commands with dynamic inputs. Pass arguments as an array to ensure they are passed directly to the executable without shell interpolation.
+# Sentinel — security learnings
+
+> ⛔ **STOP / DO-NOT-DUPLICATE.** Before opening ANY PR, search existing **open
+> AND closed** PRs and issues. If the topic below is already covered, do NOT
+> open another PR — dozens of duplicate command-injection PRs were closed as
+> noise. Only open a PR for a **new, unaddressed** finding, with a concrete
+> exploit path or failing test as evidence.
+
+## ✅ RESOLVED — Command Injection via execSync (do NOT re-open)
+
+**Status: FIXED and CLOSED. Do not open further PRs about `execSync` / command injection.**
+
+- The real vulnerability (issue #190) was fixed in **v0.21.1** by switching the
+  `specify`-spawning path to `execFileSync` (arguments as an array — no shell
+  interpolation).
+- The last shell-interpolated `execSync` (dead code in `setup.mjs`'s unused
+  `isCliAvailable`) was removed in **PR #296**.
+- Every remaining `execSync` in `cli/` uses a **static string literal**
+  (`git rev-parse …`, `git rev-list --count HEAD`, `git log … | wc -l`) with
+  **no variable interpolation** — not injectable. Leave them as-is; do not "fix" them.
+
+Historical note (kept for context, not for re-application): interpolating
+`projectDir`/`filePath` into a shell string allowed `;`/`&&`/`||` injection;
+`execFileSync` with an args array prevents it. Lesson recorded — already applied.

--- a/.wolf/anatomy.md
+++ b/.wolf/anatomy.md
@@ -1,7 +1,7 @@
 # anatomy.md
 
-> Auto-maintained by OpenWolf. Last scanned: 2026-07-06T00:51:03.699Z
-> Files: 664 tracked | Anatomy hits: 0 | Misses: 0
+> Auto-maintained by OpenWolf. Last scanned: 2026-07-06T01:05:07.108Z
+> Files: 667 tracked | Anatomy hits: 0 | Misses: 0
 
 ## ../../../../../../../tmp/
 
@@ -22,7 +22,7 @@
 - `.npmrc` — Supply-Chain Security Hardening (~59 tok)
 - `.pre-commit-hooks.yaml` — DocGuard hooks for the pre-commit framework (https://pre-commit.com). (~490 tok)
 - `action.yml` — Declares fs (~7591 tok)
-- `AGENTS.md` — AI Agent Instructions — DocGuard (~1584 tok)
+- `AGENTS.md` — AI Agent Instructions — DocGuard (~1827 tok)
 - `CHANGELOG.md` — Changelog (~45081 tok)
 - `CLAUDE.md` — OpenWolf (~57 tok)
 - `CODE_OF_CONDUCT.md` — Contributor Covenant Code of Conduct (~532 tok)
@@ -953,6 +953,12 @@
 
 - `release.yml` — CI: Auto Release — Tag, GitHub Release, npm, PyPI (~3386 tok)
 - `sync-speckit-catalog.yml` — CI: Prepare Spec Kit Catalog Submission (Manual) (~1385 tok)
+
+## .jules/
+
+- `bolt.md` — Bolt — performance learnings (~333 tok)
+- `palette.md` — Palette — UX learnings (~153 tok)
+- `sentinel.md` — Sentinel — security learnings (~329 tok)
 
 ## cli/
 

--- a/.wolf/hooks/_session.json
+++ b/.wolf/hooks/_session.json
@@ -11,6 +11,26 @@
       "count": 2,
       "tokens": 5292,
       "first_read": "2026-07-06T00:50:13.963Z"
+    },
+    "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/.jules/sentinel.md": {
+      "count": 1,
+      "tokens": 0,
+      "first_read": "2026-07-06T01:03:21.055Z"
+    },
+    "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/.jules/bolt.md": {
+      "count": 1,
+      "tokens": 0,
+      "first_read": "2026-07-06T01:03:42.419Z"
+    },
+    "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/.jules/palette.md": {
+      "count": 1,
+      "tokens": 0,
+      "first_read": "2026-07-06T01:04:03.483Z"
+    },
+    "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/AGENTS.md": {
+      "count": 1,
+      "tokens": 1584,
+      "first_read": "2026-07-06T01:04:53.189Z"
     }
   },
   "files_written": [
@@ -73,17 +93,45 @@
       "action": "edit",
       "tokens": 31,
       "at": "2026-07-06T00:51:03.770Z"
+    },
+    {
+      "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/.jules/sentinel.md",
+      "action": "create",
+      "tokens": 376,
+      "at": "2026-07-06T01:03:36.363Z"
+    },
+    {
+      "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/.jules/bolt.md",
+      "action": "create",
+      "tokens": 380,
+      "at": "2026-07-06T01:03:56.449Z"
+    },
+    {
+      "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/.jules/palette.md",
+      "action": "create",
+      "tokens": 175,
+      "at": "2026-07-06T01:04:18.656Z"
+    },
+    {
+      "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/AGENTS.md",
+      "action": "edit",
+      "tokens": 287,
+      "at": "2026-07-06T01:05:07.128Z"
     }
   ],
   "edit_counts": {
     "glama.json": 1,
     "cli/commands/mcp.mjs": 6,
     "docs-canonical/ARCHITECTURE.md": 1,
-    "cli/commands/setup.mjs": 2
+    "cli/commands/setup.mjs": 2,
+    ".jules/sentinel.md": 1,
+    ".jules/bolt.md": 1,
+    ".jules/palette.md": 1,
+    "AGENTS.md": 1
   },
-  "anatomy_hits": 1,
-  "anatomy_misses": 1,
+  "anatomy_hits": 2,
+  "anatomy_misses": 4,
   "repeated_reads_warned": 1,
   "cerebrum_warnings": 0,
-  "stop_count": 4
+  "stop_count": 5
 }

--- a/.wolf/memory.md
+++ b/.wolf/memory.md
@@ -866,3 +866,8 @@
 | 20:45 | Session end: 8 writes across 3 files (glama.json, mcp.mjs, ARCHITECTURE.md) | 1 reads | ~3860 tok |
 | 20:50 | Edited cli/commands/setup.mjs | removed 13 lines | ~11 |
 | 20:51 | Edited cli/commands/setup.mjs | 3→2 lines | ~29 |
+| 21:00 | Session end: 10 writes across 4 files (glama.json, mcp.mjs, ARCHITECTURE.md, setup.mjs) | 2 reads | ~9194 tok |
+| 21:03 | Created .jules/sentinel.md | — | ~351 |
+| 21:03 | Created .jules/bolt.md | — | ~355 |
+| 21:04 | Created .jules/palette.md | — | ~164 |
+| 21:05 | Edited AGENTS.md | expanded (+14 lines) | ~268 |

--- a/.wolf/token-ledger.json
+++ b/.wolf/token-ledger.json
@@ -2,14 +2,14 @@
   "version": 1,
   "created_at": "2026-05-26T15:31:59.491Z",
   "lifetime": {
-    "total_tokens_estimated": 5909858,
-    "total_reads": 1505,
-    "total_writes": 2332,
+    "total_tokens_estimated": 5919052,
+    "total_reads": 1507,
+    "total_writes": 2342,
     "total_sessions": 38,
-    "anatomy_hits": 921,
-    "anatomy_misses": 580,
-    "repeated_reads_blocked": 918,
-    "estimated_savings_vs_bare_cli": 5186433
+    "anatomy_hits": 922,
+    "anatomy_misses": 581,
+    "repeated_reads_blocked": 919,
+    "estimated_savings_vs_bare_cli": 5191925
   },
   "sessions": [
     {
@@ -22068,6 +22068,85 @@
         "reads_count": 1,
         "writes_count": 8,
         "repeated_reads_blocked": 0,
+        "anatomy_lookups": 1
+      }
+    },
+    {
+      "id": "session-2026-07-06-2028",
+      "started": "2026-07-06T00:28:14.541Z",
+      "ended": "2026-07-06T01:00:51.770Z",
+      "reads": [
+        {
+          "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/cli/commands/mcp.mjs",
+          "tokens_estimated": 2902,
+          "was_repeated": false,
+          "anatomy_had_description": false
+        },
+        {
+          "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/cli/commands/setup.mjs",
+          "tokens_estimated": 5292,
+          "was_repeated": true,
+          "anatomy_had_description": false
+        }
+      ],
+      "writes": [
+        {
+          "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/glama.json",
+          "tokens_estimated": 29,
+          "action": "create"
+        },
+        {
+          "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/cli/commands/mcp.mjs",
+          "tokens_estimated": 172,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/cli/commands/mcp.mjs",
+          "tokens_estimated": 141,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/cli/commands/mcp.mjs",
+          "tokens_estimated": 89,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/cli/commands/mcp.mjs",
+          "tokens_estimated": 166,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/cli/commands/mcp.mjs",
+          "tokens_estimated": 129,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/cli/commands/mcp.mjs",
+          "tokens_estimated": 114,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/docs-canonical/ARCHITECTURE.md",
+          "tokens_estimated": 118,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/cli/commands/setup.mjs",
+          "tokens_estimated": 11,
+          "action": "edit"
+        },
+        {
+          "file": "/Users/ricardoaccioly/Repo_claude/canonical-spec-kit/.claude/worktrees/intelligent-lehmann-6f6e95/cli/commands/setup.mjs",
+          "tokens_estimated": 31,
+          "action": "edit"
+        }
+      ],
+      "totals": {
+        "input_tokens_estimated": 8194,
+        "output_tokens_estimated": 1000,
+        "reads_count": 2,
+        "writes_count": 10,
+        "repeated_reads_blocked": 1,
         "anatomy_lookups": 1
       }
     }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,20 @@ extensions/spec-kit-docguard/
 
 ## Agent Rules
 
+### Automated agents / bots (Jules "Sentinel", "Bolt", "Palette", and any auto-PR agent)
+- **Never open a duplicate PR.** Before opening ANY PR, search existing **open
+  AND closed** PRs and issues for the same topic/title. If it exists, STOP — do
+  not open another. (Dozens of duplicate command-injection and diff-optimization
+  PRs were closed as noise.)
+- **Do not re-open resolved work.** See `.jules/sentinel.md` (execSync/command
+  injection — RESOLVED in v0.21.1 + #296) and `.jules/bolt.md` (diff/scan
+  micro-optimizations — already applied; code refactored since). These are
+  historical learnings, **not** standing mandates to re-scan every run.
+- **Bar for a new PR:** a genuinely new, unaddressed finding, with evidence — a
+  concrete exploit path / failing test (security) or a benchmark showing >20%
+  real-workload improvement (performance). A Big-O note alone is insufficient.
+- This repo has **no web UI and no VS Code extension** — skip all UX tasks.
+
 ### Dependencies
 - Never add a package without first verifying it exists on the official registry (npm/PyPI).
 - Always pin to exact versions in `package.json` and `requirements.txt`. No ^, ~, or >= ranges.


### PR DESCRIPTION
Root-cause fix for the 40+ duplicate Jules bot PRs. The .jules/*.md persona files read as open-ended mandates, so Jules re-found + re-opened the same issues every run. Now each carries a STOP/RESOLVED header (execSync fixed v0.21.1+#296; diff opts applied+refactored; no UI/VSCode-ext for Palette), plus an AGENTS.md rule: search open+closed PRs first, never duplicate, evidence bar for new PRs. Guard PASS 269, docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)