### PR TITLE
ci: add Node 24 (npm 11) to matrices — prevent the .npmrc-style regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        # 24 ships npm 11 — keep it in the matrix so `npm ci` exercises the newer
+        # npm that older Nodes (18/20/22 → npm 10) do NOT. This is what catches
+        # config/install incompatibilities that npm 10 silently accepts but npm 11
+        # treats as fatal (e.g. bug-198: `.npmrc` min-release-age broke the Glama
+        # build on npm 11 while all local/CI installs passed). Do not drop 24.
+        node-version: [18, 20, 22, 24]
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        # 24 = npm 11 coverage (18/20/22 ship npm 10). Gates releases on the
+        # newer npm so a version-incompatible .npmrc / install can't ship (bug-198).
+        node-version: [18, 20, 22, 24]
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
Root-cause prevention for bug-198. The matrix (18/20/22) all ship npm 10, which accepted the bad `.npmrc`; only Glama's Node 26 (npm 11) rejected it, so CI never caught it. Adding Node 24 (= npm 11) runs `npm ci` on the newer npm in both CI and the release gate — any npm-version config/install incompatibility now fails a PR check before it can reach Glama / the registry / users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)