### PR TITLE
release: v0.33.0 — enterprise evidence batch

### DIFF
--- a/.github/scripts/speckit-submission.py
+++ b/.github/scripts/speckit-submission.py
@@ -61,11 +61,13 @@ def build(version: str, download_url: str):
             "name": "DocGuard — CDD Enforcement",
             "id": "docguard",
             "description": (
-                "The only doc-integrity engine with an MCP server, SARIF "
-                "output, and a deterministic zero-LLM core. Validates, "
-                "scores, and traces documentation against code — 27 "
-                "validators, stable finding codes, GitHub Action with PR "
-                "annotations, spec-kit hooks. Pure Node.js, one pinned dep."
+                "The only doc-integrity engine with an MCP server, "
+                "SARIF/JUnit output, and a deterministic zero-LLM core. "
+                "Validates, scores, and traces documentation against code — "
+                "27 validators, stable finding codes, adoption baseline for "
+                "legacy repos, compliance-evidence reports, GitHub Action "
+                "with PR annotations, spec-kit hooks. Pure Node.js, one "
+                "pinned dep."
             ),
             "author": "raccioly",
             "version": version,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-07-16
+
 ### Added
 
 - **Adoption baseline — `guard --update-baseline` + committed `.docguard.baseline.json`.** The ESLint/semgrep-style brownfield pattern: freeze a legacy repo's existing findings once, commit the file, and guard/ci gate only NEW drift from then on — no red pipeline on adoption day. Fingerprints are content-addressed (finding code + location path with line numbers stripped + message with digit-runs normalized), so they survive line churn and volatile counts ("21 commits since…") — and they carry **occurrence counts**: freezing one hardcoded-secret finding in a file suppresses exactly one; a second instance of the same class surfaces and gates (the ESLint-baseline semantics). Suppression is never silent: the summary prints "N pre-existing finding(s) suppressed", `baselineSuppressed` rides the JSON contract, and `--no-baseline` (or `"baseline": false` in `.docguard.json`) shows everything. A malformed baseline is treated as absent — corruption can never un-gate CI. Applied inside `runGuardInternal`, so guard, ci, report, SARIF/JUnit outputs, and the MCP tools all honor it uniformly. Also: DocGuard's own files (`.docguard.json`, `.docguardignore`, `.docguard.baseline.json`) are exempt from Docs-Coverage's undocumented-config check — writing the baseline no longer instantly creates a DCV001 about the baseline.

--- a/extensions/spec-kit-docguard/extension.yml
+++ b/extensions/spec-kit-docguard/extension.yml
@@ -3,7 +3,7 @@ schema_version: "1.0"
 extension:
   id: "docguard"
   name: "DocGuard — CDD Enforcement"
-  version: "0.32.0"
+  version: "0.33.0"
   description: "Canonical-Driven Development enforcement as a true spec-kit extension. LLM-first design with automated validators, 4 AI behavior skills, spec-kit skill chaining, and workflow hooks. One pinned runtime dependency (@babel/parser); pure Node.js otherwise."
   author: "Ricardo Accioly"
   repository: "https://github.com/raccioly/docguard"

--- a/extensions/spec-kit-docguard/skills/docguard-fix/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-fix/SKILL.md
@@ -6,10 +6,10 @@ description: AI-driven documentation repair with structured research workflow, t
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.32.0
+  version: 0.33.0
   source: extensions/spec-kit-docguard/skills/docguard-fix
 ---
-<!-- docguard:version: 0.32.0 -->
+<!-- docguard:version: 0.33.0 -->
 
 # DocGuard Fix Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-guard/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-guard/SKILL.md
@@ -7,10 +7,10 @@ description: Run DocGuard guard validation against Canonical-Driven Development 
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.32.0
+  version: 0.33.0
   source: extensions/spec-kit-docguard/skills/docguard-guard
 ---
-<!-- docguard:version: 0.32.0 -->
+<!-- docguard:version: 0.33.0 -->
 
 # DocGuard Guard Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-review/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-review/SKILL.md
@@ -6,10 +6,10 @@ description: Cross-document consistency analysis and quality assessment. Perform
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.32.0
+  version: 0.33.0
   source: extensions/spec-kit-docguard/skills/docguard-review
 ---
-<!-- docguard:version: 0.32.0 -->
+<!-- docguard:version: 0.33.0 -->
 
 # DocGuard Review Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-score/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-score/SKILL.md
@@ -6,10 +6,10 @@ description: CDD maturity assessment with category-aware improvement roadmap. Ru
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.32.0
+  version: 0.33.0
   source: extensions/spec-kit-docguard/skills/docguard-score
 ---
-<!-- docguard:version: 0.32.0 -->
+<!-- docguard:version: 0.33.0 -->
 
 # DocGuard Score Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-sync/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-sync/SKILL.md
@@ -4,10 +4,10 @@ description: Keep canonical documentation ALWAYS UP TO DATE. Refreshes code-trut
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.32.0
+  version: 0.33.0
   source: extensions/spec-kit-docguard/skills/docguard-sync
 ---
-<!-- docguard:version: 0.32.0 -->
+<!-- docguard:version: 0.33.0 -->
 
 # DocGuard Sync Skill
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docguard-cli",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "description": "The enforcement tool for Canonical-Driven Development (CDD). Audit, generate, and guard your project documentation.",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.raccioly/docguard",
   "title": "DocGuard",
   "description": "Deterministic doc-drift detection: guard, score, explain, verify-claims and diagnose MCP tools.",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "websiteUrl": "https://github.com/raccioly/docguard#readme",
   "repository": {
     "url": "https://github.com/raccioly/docguard",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "docguard-cli",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

Version bump for the v0.33.0 release (features merged in #317):
- `package.json` + `server.json` → 0.33.0
- CHANGELOG `[Unreleased]` → `[0.33.0] - 2026-07-16`
- extension.yml + skill files version-synced via `docguard fix --write`
- spec-kit catalog description updated (SARIF/JUnit, adoption baseline, compliance-evidence reports)

Merging this triggers release.yml (package.json path filter): tag → GitHub Release (extension ZIP) → npm → PyPI.

## Test plan
- [x] 1018/1018 tests passing at the bumped version
- [x] Self-guard clean (0 errors; metadata-sync happy with the new version stamps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)