### PR TITLE
release: v0.33.1 — activates npm provenance + first .mcpb bundle

### DIFF
--- a/.agent/skills/docguard-fix/SKILL.md
+++ b/.agent/skills/docguard-fix/SKILL.md
@@ -6,10 +6,10 @@ description: AI-driven documentation repair with structured research workflow, t
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.33.0
+  version: 0.33.1
   source: extensions/spec-kit-docguard/skills/docguard-fix
 ---
-<!-- docguard:version: 0.33.0 -->
+<!-- docguard:version: 0.33.1 -->
 
 # DocGuard Fix Skill
 

--- a/.agent/skills/docguard-guard/SKILL.md
+++ b/.agent/skills/docguard-guard/SKILL.md
@@ -7,10 +7,10 @@ description: Run DocGuard guard validation against Canonical-Driven Development 
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.33.0
+  version: 0.33.1
   source: extensions/spec-kit-docguard/skills/docguard-guard
 ---
-<!-- docguard:version: 0.33.0 -->
+<!-- docguard:version: 0.33.1 -->
 
 # DocGuard Guard Skill
 

--- a/.agent/skills/docguard-review/SKILL.md
+++ b/.agent/skills/docguard-review/SKILL.md
@@ -6,10 +6,10 @@ description: Cross-document consistency analysis and quality assessment. Perform
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.33.0
+  version: 0.33.1
   source: extensions/spec-kit-docguard/skills/docguard-review
 ---
-<!-- docguard:version: 0.33.0 -->
+<!-- docguard:version: 0.33.1 -->
 
 # DocGuard Review Skill
 

--- a/.agent/skills/docguard-score/SKILL.md
+++ b/.agent/skills/docguard-score/SKILL.md
@@ -6,10 +6,10 @@ description: CDD maturity assessment with category-aware improvement roadmap. Ru
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.33.0
+  version: 0.33.1
   source: extensions/spec-kit-docguard/skills/docguard-score
 ---
-<!-- docguard:version: 0.33.0 -->
+<!-- docguard:version: 0.33.1 -->
 
 # DocGuard Score Skill
 

--- a/.agent/skills/docguard-sync/SKILL.md
+++ b/.agent/skills/docguard-sync/SKILL.md
@@ -4,10 +4,10 @@ description: Keep canonical documentation ALWAYS UP TO DATE. Refreshes code-trut
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.33.0
+  version: 0.33.1
   source: extensions/spec-kit-docguard/skills/docguard-sync
 ---
-<!-- docguard:version: 0.33.0 -->
+<!-- docguard:version: 0.33.1 -->
 
 # DocGuard Sync Skill
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.1] - 2026-07-16
+
 ### Added
 
 - **Claude Desktop one-click extension (`.mcpb`).** Each release now attaches `docguard-v<version>.mcpb` — the official MCP Bundle format: drag into Claude Desktop → Settings → Extensions, pick the project folder, done. No npm, no JSON editing. Built by the new `build-mcpb` release job from the exact npm-pack payload (manifest template in `mcpb/`, packed with `@anthropic-ai/mcpb`). README gained one-click install badges for Cursor and VS Code (MCP deeplinks) alongside the Claude Code and registry paths.

--- a/extensions/spec-kit-docguard/extension.yml
+++ b/extensions/spec-kit-docguard/extension.yml
@@ -3,7 +3,7 @@ schema_version: "1.0"
 extension:
   id: "docguard"
   name: "DocGuard — CDD Enforcement"
-  version: "0.33.0"
+  version: "0.33.1"
   description: "Canonical-Driven Development enforcement as a true spec-kit extension. LLM-first design with automated validators, 4 AI behavior skills, spec-kit skill chaining, and workflow hooks. One pinned runtime dependency (@babel/parser); pure Node.js otherwise."
   author: "Ricardo Accioly"
   repository: "https://github.com/raccioly/docguard"

--- a/extensions/spec-kit-docguard/skills/docguard-fix/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-fix/SKILL.md
@@ -6,10 +6,10 @@ description: AI-driven documentation repair with structured research workflow, t
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.33.0
+  version: 0.33.1
   source: extensions/spec-kit-docguard/skills/docguard-fix
 ---
-<!-- docguard:version: 0.33.0 -->
+<!-- docguard:version: 0.33.1 -->
 
 # DocGuard Fix Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-guard/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-guard/SKILL.md
@@ -7,10 +7,10 @@ description: Run DocGuard guard validation against Canonical-Driven Development 
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.33.0
+  version: 0.33.1
   source: extensions/spec-kit-docguard/skills/docguard-guard
 ---
-<!-- docguard:version: 0.33.0 -->
+<!-- docguard:version: 0.33.1 -->
 
 # DocGuard Guard Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-review/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-review/SKILL.md
@@ -6,10 +6,10 @@ description: Cross-document consistency analysis and quality assessment. Perform
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.33.0
+  version: 0.33.1
   source: extensions/spec-kit-docguard/skills/docguard-review
 ---
-<!-- docguard:version: 0.33.0 -->
+<!-- docguard:version: 0.33.1 -->
 
 # DocGuard Review Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-score/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-score/SKILL.md
@@ -6,10 +6,10 @@ description: CDD maturity assessment with category-aware improvement roadmap. Ru
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.33.0
+  version: 0.33.1
   source: extensions/spec-kit-docguard/skills/docguard-score
 ---
-<!-- docguard:version: 0.33.0 -->
+<!-- docguard:version: 0.33.1 -->
 
 # DocGuard Score Skill
 

--- a/extensions/spec-kit-docguard/skills/docguard-sync/SKILL.md
+++ b/extensions/spec-kit-docguard/skills/docguard-sync/SKILL.md
@@ -4,10 +4,10 @@ description: Keep canonical documentation ALWAYS UP TO DATE. Refreshes code-trut
 compatibility: Requires DocGuard CLI installed (npm i -g docguard-cli or npx docguard-cli)
 metadata:
   author: docguard
-  version: 0.33.0
+  version: 0.33.1
   source: extensions/spec-kit-docguard/skills/docguard-sync
 ---
-<!-- docguard:version: 0.33.0 -->
+<!-- docguard:version: 0.33.1 -->
 
 # DocGuard Sync Skill
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docguard-cli",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "The enforcement tool for Canonical-Driven Development (CDD). Audit, generate, and guard your project documentation.",
   "type": "module",
   "bin": {

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.raccioly/docguard",
   "title": "DocGuard",
   "description": "Deterministic doc-drift detection: guard, score, explain, verify-claims and diagnose MCP tools.",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "websiteUrl": "https://github.com/raccioly/docguard#readme",
   "repository": {
     "url": "https://github.com/raccioly/docguard",
@@ -14,7 +14,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "docguard-cli",
-      "version": "0.33.0",
+      "version": "0.33.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

Patch release whose whole point is distribution trust (features unchanged from 0.33.0):

- First publish through the new `npm publish --provenance` path — the tarball gets a Sigstore attestation (npm Provenance badge; passes unknown-package legitimacy checks).
- First release with `docguard-v0.33.1.mcpb` attached — one-click Claude Desktop install via the new `build-mcpb` job.
- package.json + server.json → 0.33.1, CHANGELOG dated, skill/extension version markers synced.

Merging triggers release.yml: tag → GitHub Release (extension ZIP + .mcpb) → npm (with provenance) → PyPI.

## Test plan
- [x] 1018/1018 tests at the bumped version; self-guard clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)